### PR TITLE
Error Reporting: stdout & Sentry

### DIFF
--- a/api/accounts/post_account.go
+++ b/api/accounts/post_account.go
@@ -27,7 +27,7 @@ func postAccount(app *api.App) http.HandlerFunc {
 
 		err = api.RevokeSession(app.RefreshTokenStore, app.Config, r)
 		if err != nil {
-			// TODO: alert but continue
+			app.Reporter.ReportError(err)
 		}
 
 		sessionToken, identityToken, err := api.NewSession(app.RefreshTokenStore, app.KeyStore, app.Actives, app.Config, account.ID, api.MatchedDomain(r))

--- a/api/accounts/post_account.go
+++ b/api/accounts/post_account.go
@@ -27,7 +27,7 @@ func postAccount(app *api.App) http.HandlerFunc {
 
 		err = api.RevokeSession(app.RefreshTokenStore, app.Config, r)
 		if err != nil {
-			app.Reporter.ReportError(err)
+			app.Reporter.ReportRequestError(err, r)
 		}
 
 		sessionToken, identityToken, err := api.NewSession(app.RefreshTokenStore, app.KeyStore, app.Actives, app.Config, account.ID, api.MatchedDomain(r))

--- a/api/meta/get_jwks.go
+++ b/api/meta/get_jwks.go
@@ -13,12 +13,17 @@ func getJWKs(app *api.App) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		keys := []jose.JSONWebKey{}
 		for _, key := range app.KeyStore.Keys() {
-			keys = append(keys, jose.JSONWebKey{
-				Key:       key.Public(),
-				Use:       "sig",
-				Algorithm: "RS256",
-				KeyID:     compat.KeyID(key.Public()),
-			})
+			keyID, err := compat.KeyID(key.Public())
+			if err != nil {
+				app.Reporter.ReportError(err)
+			} else {
+				keys = append(keys, jose.JSONWebKey{
+					Key:       key.Public(),
+					Use:       "sig",
+					Algorithm: "RS256",
+					KeyID:     keyID,
+				})
+			}
 		}
 
 		api.WriteJSON(w, http.StatusOK, jose.JSONWebKeySet{Keys: keys})

--- a/api/meta/get_jwks.go
+++ b/api/meta/get_jwks.go
@@ -15,7 +15,7 @@ func getJWKs(app *api.App) http.HandlerFunc {
 		for _, key := range app.KeyStore.Keys() {
 			keyID, err := compat.KeyID(key.Public())
 			if err != nil {
-				app.Reporter.ReportError(err)
+				app.Reporter.ReportRequestError(err, r)
 			} else {
 				keys = append(keys, jose.JSONWebKey{
 					Key:       key.Public(),

--- a/api/passwords/get_password_reset.go
+++ b/api/passwords/get_password_reset.go
@@ -18,7 +18,7 @@ func getPasswordReset(app *api.App) http.HandlerFunc {
 		go func() {
 			err := services.PasswordResetSender(app.Config, account)
 			if err != nil {
-				app.Reporter.ReportError(err)
+				app.Reporter.ReportRequestError(err, r)
 			}
 		}()
 

--- a/api/passwords/get_password_reset.go
+++ b/api/passwords/get_password_reset.go
@@ -18,7 +18,7 @@ func getPasswordReset(app *api.App) http.HandlerFunc {
 		go func() {
 			err := services.PasswordResetSender(app.Config, account)
 			if err != nil {
-				// TODO: report and continue
+				app.Reporter.ReportError(err)
 			}
 		}()
 

--- a/api/passwords/post_password.go
+++ b/api/passwords/post_password.go
@@ -43,7 +43,7 @@ func postPassword(app *api.App) http.HandlerFunc {
 
 		err = api.RevokeSession(app.RefreshTokenStore, app.Config, r)
 		if err != nil {
-			// TODO: alert but continue
+			app.Reporter.ReportError(err)
 		}
 
 		sessionToken, identityToken, err := api.NewSession(app.RefreshTokenStore, app.KeyStore, app.Actives, app.Config, accountID, api.MatchedDomain(r))

--- a/api/passwords/post_password.go
+++ b/api/passwords/post_password.go
@@ -43,7 +43,7 @@ func postPassword(app *api.App) http.HandlerFunc {
 
 		err = api.RevokeSession(app.RefreshTokenStore, app.Config, r)
 		if err != nil {
-			app.Reporter.ReportError(err)
+			app.Reporter.ReportRequestError(err, r)
 		}
 
 		sessionToken, identityToken, err := api.NewSession(app.RefreshTokenStore, app.KeyStore, app.Actives, app.Config, accountID, api.MatchedDomain(r))

--- a/api/session.go
+++ b/api/session.go
@@ -23,13 +23,13 @@ func Session(app *App) func(http.Handler) http.Handler {
 					if err == http.ErrNoCookie {
 						return
 					} else if err != nil {
-						app.Reporter.ReportError(err)
+						app.Reporter.ReportRequestError(err, r)
 						return
 					}
 
 					session, err = sessions.Parse(cookie.Value, app.Config)
 					if err != nil {
-						app.Reporter.ReportError(err)
+						app.Reporter.ReportRequestError(err, r)
 					}
 				})
 
@@ -48,7 +48,7 @@ func Session(app *App) func(http.Handler) http.Handler {
 
 					accountID, err = app.RefreshTokenStore.Find(models.RefreshToken(session.Subject))
 					if err != nil {
-						app.Reporter.ReportError(err)
+						app.Reporter.ReportRequestError(err, r)
 					}
 				})
 

--- a/api/session.go
+++ b/api/session.go
@@ -23,13 +23,13 @@ func Session(app *App) func(http.Handler) http.Handler {
 					if err == http.ErrNoCookie {
 						return
 					} else if err != nil {
-						// TODO: record and continue
+						app.Reporter.ReportError(err)
 						return
 					}
 
 					session, err = sessions.Parse(cookie.Value, app.Config)
 					if err != nil {
-						// TODO: record and continue
+						app.Reporter.ReportError(err)
 					}
 				})
 
@@ -48,7 +48,7 @@ func Session(app *App) func(http.Handler) http.Handler {
 
 					accountID, err = app.RefreshTokenStore.Find(models.RefreshToken(session.Subject))
 					if err != nil {
-						// TODO: record and continue
+						app.Reporter.ReportError(err)
 					}
 				})
 

--- a/api/session_test.go
+++ b/api/session_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/keratin/authn-server/api/test"
 	"github.com/keratin/authn-server/config"
 	"github.com/keratin/authn-server/data/mock"
+	"github.com/keratin/authn-server/ops"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -23,6 +24,7 @@ func TestSession(t *testing.T) {
 			ApplicationDomains: []config.Domain{{Hostname: "example.com"}},
 		},
 		RefreshTokenStore: mock.NewRefreshTokenStore(),
+		Reporter:          &ops.LogReporter{},
 	}
 
 	t.Run("valid session", func(t *testing.T) {

--- a/api/sessions/delete_session.go
+++ b/api/sessions/delete_session.go
@@ -10,7 +10,7 @@ func deleteSession(app *api.App) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		err := api.RevokeSession(app.RefreshTokenStore, app.Config, r)
 		if err != nil {
-			// TODO: alert but continue
+			app.Reporter.ReportError(err)
 		}
 
 		api.SetSession(app.Config, w, "")

--- a/api/sessions/delete_session.go
+++ b/api/sessions/delete_session.go
@@ -10,7 +10,7 @@ func deleteSession(app *api.App) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		err := api.RevokeSession(app.RefreshTokenStore, app.Config, r)
 		if err != nil {
-			app.Reporter.ReportError(err)
+			app.Reporter.ReportRequestError(err, r)
 		}
 
 		api.SetSession(app.Config, w, "")

--- a/api/sessions/get_session_refresh_test.go
+++ b/api/sessions/get_session_refresh_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/keratin/authn-server/api/test"
 	"github.com/keratin/authn-server/config"
 	"github.com/keratin/authn-server/data/mock"
+	"github.com/keratin/authn-server/ops"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -39,6 +40,7 @@ func TestGetSessionRefreshFailure(t *testing.T) {
 			ApplicationDomains: []config.Domain{{Hostname: "test.com"}},
 		},
 		RefreshTokenStore: mock.NewRefreshTokenStore(),
+		Reporter:          &ops.LogReporter{},
 	}
 	server := test.Server(app, apiSessions.Routes(app))
 	defer server.Close()

--- a/api/sessions/post_session.go
+++ b/api/sessions/post_session.go
@@ -27,7 +27,7 @@ func postSession(app *api.App) http.HandlerFunc {
 
 		err = api.RevokeSession(app.RefreshTokenStore, app.Config, r)
 		if err != nil {
-			app.Reporter.ReportError(err)
+			app.Reporter.ReportRequestError(err, r)
 		}
 
 		sessionToken, identityToken, err := api.NewSession(app.RefreshTokenStore, app.KeyStore, app.Actives, app.Config, account.ID, api.MatchedDomain(r))

--- a/api/sessions/post_session.go
+++ b/api/sessions/post_session.go
@@ -27,7 +27,7 @@ func postSession(app *api.App) http.HandlerFunc {
 
 		err = api.RevokeSession(app.RefreshTokenStore, app.Config, r)
 		if err != nil {
-			// TODO: alert but continue
+			app.Reporter.ReportError(err)
 		}
 
 		sessionToken, identityToken, err := api.NewSession(app.RefreshTokenStore, app.KeyStore, app.Actives, app.Config, account.ID, api.MatchedDomain(r))

--- a/api/test/app.go
+++ b/api/test/app.go
@@ -8,6 +8,7 @@ import (
 	"github.com/keratin/authn-server/api"
 	"github.com/keratin/authn-server/config"
 	"github.com/keratin/authn-server/data/mock"
+	"github.com/keratin/authn-server/ops"
 )
 
 func App() *api.App {
@@ -38,5 +39,6 @@ func App() *api.App {
 		AccountStore:      mock.NewAccountStore(),
 		RefreshTokenStore: mock.NewRefreshTokenStore(),
 		Actives:           mock.NewActives(),
+		Reporter:          &ops.LogReporter{},
 	}
 }

--- a/compat/key_id.go
+++ b/compat/key_id.go
@@ -6,20 +6,21 @@ import (
 	"encoding/base64"
 	"fmt"
 
+	"github.com/pkg/errors"
 	jose "github.com/square/go-jose"
 )
 
-func KeyID(key crypto.PublicKey) string {
+func KeyID(key crypto.PublicKey) (string, error) {
 	rsaKey, ok := key.(*rsa.PublicKey)
 	if !ok {
-		panic(fmt.Errorf("Not a RSA key"))
+		return "", fmt.Errorf("Not a RSA key")
 	}
 
 	jwk := jose.JSONWebKey{Key: rsaKey}
 	kid, err := jwk.Thumbprint(crypto.SHA256)
 	if err != nil {
-		panic(err)
+		return "", errors.Wrap(err, "jwk.Thumbprint")
 	}
 
-	return base64.RawURLEncoding.EncodeToString(kid)
+	return base64.RawURLEncoding.EncodeToString(kid), nil
 }

--- a/compat/key_id_test.go
+++ b/compat/key_id_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/keratin/authn-server/compat"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestKeyID(t *testing.T) {
@@ -14,6 +15,7 @@ func TestKeyID(t *testing.T) {
 	serialized := []byte("-----BEGIN RSA PRIVATE KEY-----\nMIIEowIBAAKCAQEAteQCTn7AGpoFG+IDZ3UNwHsG8KYXIw7JRp/vlN8/Gqj9FLZj\neq0NBUe9u1qLQOy0PLKAV9BkmT1iKbCJdSbhWz39apWFw95thYRGX5xapF6VI4jr\noUsdINNbOUdRkc9mDsqDZo0d8JGsWv1hA+2SGuI6P4s7Lf/cmzYFh++Jy01qBwyd\n5mHSayDD2oApcGlkOOjfUbb2DZveceKpD+0rq4abICzI1GfuC/Gnedw7hE4XChJ4\nHKuBEcHC9leBQmZ40PF35YBHaja0Uy8QtNalILRPFAC2jEXJkyez9Z27clVReD/n\nPcfZ/9bs7W1+VfZrVSIIHda55gYJRCTr8MMsLQIDAQABAoIBAQCHj6PYdMcgDGJ6\nYXxAAxF4vzhw6pib3E1OgazBu5EAgan9YeHKcGcf5FQX6meWv9Ok2TSmPf575y/d\n+mC4G34hzpWsdjv3uzLNK8R3RcSYdJWaolVbJOxUprF6gxjcH0LlCzHboJkLzsYy\nGl3P26PkvW7EJTS6F9OHKj/9DB4akhoX6af2C1ivL/TPg+GDUFMNNeEvXk/WhAdC\nm/RPLmTiFi9h0AsS40NW3zX8Dft3mBEWaNsrcQH5CJz23ozpbq6pA4ZqLXUlAtrI\nPXx5FCM5q+VJPHE1cnmthZHVXsOo7uwORm7U2ry2PUzBJ4kQx3LfybRNcIfU8K5y\nejoXrjwBAoGBANN6PEWbtyLAsXLVfSFI/Jk36+Sm6uJh0vnDHP6KlhHY3yzP5ruo\nSh7F2vRErYk+uK7k43oyzG0PyJCnket1g3c8oZAn11pm7GtyEAJOGcGrKoiCjR4x\n5gtDbZgGxr07CN/RyE+ZbNMoutWXRrPUfLxNPRRLdWWfKlwdfH/PDDttAoGBANwv\nKnOsUu9CZ5Sc0Eq4nev+h8t9dAIehnfB2qhNmhUv6PAbJu9odioKLdyN0kP33rIj\nPp+MxCbtmmeU7Bk1CqEEe5lC1A3EivY9w0+b7A64hmfiuP8XVJ2gojvTajOoGJ0w\nC6OolQx+4TTiRzDakpdzFXbbDiJ0+k8blcLE0XvBAoGACsB4OAHGudmaLAB2sC6J\nyTByqdlir8fRdilZXAenwZiJIDohvQC9Y/sjOrATMpshwKKafif/BLx8sf4TCSmc\nWX+Xp0CfTlVVR9Ewxy05WgNd0jrw+cwHqiLve388s3pA5UBBMurWAZZciWd7jMEM\n5nX22QVNHrGM8cn9/nGEabECgYB8LzHvSbsA7OAExqkH67ZOGyG12IzsgRDwTGqp\n0BLebkYf3gCIuM8kiNcy9N4prYxxxkUUsc0T86DJWQoMcYkMJb4cQ7/cAAUsOsuE\ng/mQl+xefVY/sYXs3WODAIt+lQlE5os6A+QExy73p8PlPvG875Ckl4oSTw26PmGq\nF13bQQKBgA4wO1Xq5TaRWa8R5jb5f1Y/8JX5GybWaD1H2wB0lX/W/E064Z5hIgoM\n+DwqzJKNkhEEdtHXMJS10qV/qcGmOHOE1FUnWjQ/20s6GpImb45H84aJwvKmvPf8\nmn0NHZRqGdMecEfREyT2oYEQ+pfdJ4t6LTJGiHxYYt7WzpzOZ1cU\n-----END RSA PRIVATE KEY-----\n")
 	block, _ := pem.Decode(serialized)
 	key, _ := x509.ParsePKCS1PrivateKey(block.Bytes)
-
-	assert.Equal(t, expected, compat.KeyID(key.Public()))
+	keyID, err := compat.KeyID(key.Public())
+	require.NoError(t, err)
+	assert.Equal(t, expected, keyID)
 }

--- a/config/config.go
+++ b/config/config.go
@@ -45,6 +45,7 @@ type Config struct {
 	StatisticsTimeZone     *time.Location
 	DailyActivesRetention  int
 	WeeklyActivesRetention int
+	SentryDSN              string
 }
 
 var configurers = []configurer{
@@ -342,6 +343,15 @@ var configurers = []configurer{
 			c.WeeklyActivesRetention = num
 		}
 		return err
+	},
+
+	// SENTRY_DSN is a configuration string for the Sentry error reporting backend. When provided,
+	// errors and panics will be reported asynchronously.
+	func(c *Config) error {
+		if val, ok := os.LookupEnv("SENTRY_DSN"); ok {
+			c.SentryDSN = val
+		}
+		return nil
 	},
 
 	func(c *Config) error {

--- a/data/redis/key_store.go
+++ b/data/redis/key_store.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/go-redis/redis"
+	"github.com/keratin/authn-server/ops"
 	"github.com/pkg/errors"
 )
 
@@ -20,7 +21,7 @@ type keyStore struct {
 // regularly. The key is encrypted using SECRET_KEY_BASE, which is already the ultimate SPOF for
 // AuthN security. It's expected that very few people will be in position to improve on the security
 // tradeoffs of this provider.
-func NewKeyStore(client *redis.Client, interval time.Duration, race time.Duration, encryptionKey []byte) (*keyStore, error) {
+func NewKeyStore(client *redis.Client, reporter ops.ErrorReporter, interval time.Duration, race time.Duration, encryptionKey []byte) (*keyStore, error) {
 	ks := &keyStore{
 		keys:   []*rsa.PrivateKey{},
 		rwLock: &sync.RWMutex{},
@@ -33,7 +34,7 @@ func NewKeyStore(client *redis.Client, interval time.Duration, race time.Duratio
 		client:        client,
 		encryptionKey: encryptionKey,
 	}
-	err := m.maintain(ks)
+	err := m.maintain(ks, reporter)
 	if err != nil {
 		return nil, errors.Wrap(err, "maintain")
 	}

--- a/data/redis/key_store_maintainer.go
+++ b/data/redis/key_store_maintainer.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/go-redis/redis"
 	"github.com/keratin/authn-server/compat"
+	"github.com/keratin/authn-server/ops"
 	"github.com/pkg/errors"
 )
 
@@ -32,7 +33,7 @@ type maintainer struct {
 }
 
 // maintain will restore and rotate a keyStore at periodic intervals.
-func (m *maintainer) maintain(ks *keyStore) error {
+func (m *maintainer) maintain(ks *keyStore, r ops.ErrorReporter) error {
 	// fetch current keys
 	keys, err := m.restore()
 	if err != nil {
@@ -60,7 +61,7 @@ func (m *maintainer) maintain(ks *keyStore) error {
 		for range ticker {
 			err = m.rotate(ks)
 			if err != nil {
-				// TODO: report
+				r.ReportError(err)
 			}
 		}
 	}()

--- a/docs/config.md
+++ b/docs/config.md
@@ -11,6 +11,7 @@ title: Server Configuration
 * Password Policy: [`PASSWORD_POLICY_SCORE`](#password_policy_score) • [`BCRYPT_COST`](#bcrypt_cost)
 * Password Resets: [`APP_PASSWORD_RESET_URL`](#app_password_reset_url) • [`PASSWORD_RESET_TOKEN_TTL`](#password_reset_token_ttl)
 * Stats: [`TIME_ZONE`](#time_zone) • [`DAILY_ACTIVES_RETENTION`](#daily_actives_retention) • [`WEEKLY_ACTIVES_RETENTION`](#weekly_actives_retention)
+* Operations: [`SENTRY_DSN`](#sentry_dsn)
 
 ## Core Settings
 
@@ -238,3 +239,15 @@ Stats on daily actives will be set to expire after this many days. No mechanism 
 | Default | `104` (~2 years) |
 
 Stats on weekly actives will be set to expire after this many weeks. No mechanism is provided for changing this TTL retroactively.
+
+## Operations
+
+### `SENTRY_DSN`
+
+|           |     |
+| --------- | --- |
+| Required? | No |
+| Value | string |
+| Default | nil |
+
+Configures AuthN to report panics and unhandled errors to a Sentry backend.

--- a/glide.lock
+++ b/glide.lock
@@ -1,10 +1,14 @@
-hash: d6240e17deac9c6af046884043ca351a7b10cc4fe3ba1c956b133f376d813c37
-updated: 2017-09-01T13:35:21.096893381-07:00
+hash: 29abb000b55b2edf14af6141701d7dda3d68cfe9fdf6a0a71bbdcca24c93c17e
+updated: 2017-09-10T13:02:12.874180961-07:00
 imports:
+- name: github.com/certifi/gocertifi
+  version: 3fd9e1adb12b72d2f3f82191d49be9b93c69f67c
 - name: github.com/davecgh/go-spew
   version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
   subpackages:
   - spew
+- name: github.com/getsentry/raven-go
+  version: d175f85701dfbf44cb0510114c9943e665e60907
 - name: github.com/go-redis/redis
   version: 74d5147d860804ea34633071d0c91a7f4b0b5c3a
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -26,3 +26,4 @@ import:
   version: ^1.3.0
 - package: github.com/pkg/errors
   version: ^0.8.0
+- package: github.com/getsentry/raven-go

--- a/ops/reporter.go
+++ b/ops/reporter.go
@@ -1,0 +1,78 @@
+package ops
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	raven "github.com/getsentry/raven-go"
+)
+
+// ErrorReporter is a thing that exports details about errors and panics to another service.
+type ErrorReporter interface {
+	ReportError(err error)
+	ReportRequestError(err error, r *http.Request)
+	PanicHandler(http http.Handler) http.Handler
+}
+
+// LogReporter is an ErrorReporter that prints to a log (currently STDOUT)
+type LogReporter struct{}
+
+// ReportError reports some error information to STDOUT. The printed details are not robust.
+func (r *LogReporter) ReportError(err error) {
+	fmt.Printf("[%v] %v\n", time.Now(), err)
+}
+
+// ReportRequestError reports some error information to STDOUT. The printed details are not robust.
+func (r *LogReporter) ReportRequestError(err error, req *http.Request) {
+	fmt.Printf("[%v] %v\n", time.Now(), err)
+}
+
+// PanicHandler returns a http.Handler that will recover any panics and print some information to
+// STDOUT. The printed details are not robust. If a panic is caught, the handler will return HTTP
+// 500.
+func (r *LogReporter) PanicHandler(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		defer func() {
+			err := recover()
+			if err != nil {
+				fmt.Printf("[%v] %v", time.Now(), err)
+				w.WriteHeader(http.StatusInternalServerError)
+			}
+		}()
+
+		next.ServeHTTP(w, req)
+	})
+}
+
+// SentryReporter is an ErrorReporter for the Sentry service (sentry.io)
+type SentryReporter struct {
+	*raven.Client
+}
+
+// ReportError will deliver the given error to Sentry in a background routine.
+func (r *SentryReporter) ReportError(err error) {
+	r.CaptureError(err, map[string]string{})
+}
+
+// ReportRequestError will deliver the given error to Sentry in a background routine along with
+// data relevant to the current http.Request
+func (r *SentryReporter) ReportRequestError(err error, req *http.Request) {
+	r.CaptureError(err, map[string]string{}, raven.NewHttp(req))
+}
+
+// PanicHandler returns a http.Handler that will recover any panics and deliver them to Sentry
+// in a background routine. If a panic is caught, the handler will return HTTP 500.
+func (r *SentryReporter) PanicHandler(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		err, _ := r.CapturePanic(
+			func() { next.ServeHTTP(w, req) },
+			map[string]string{},
+			raven.NewHttp(req),
+		)
+		if err != nil {
+			// TODO: log the sentryID for forensics
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	})
+}

--- a/routing.go
+++ b/routing.go
@@ -42,7 +42,7 @@ func router(app *api.App) http.Handler {
 
 	session := api.Session(app)
 
-	return gorilla.RecoveryHandler(gorilla.PrintRecoveryStack(true))(
+	return app.Reporter.PanicHandler(
 		corsAdapter(
 			session(
 				gorilla.CombinedLoggingHandler(os.Stdout, r),

--- a/tokens/identities/identity.go
+++ b/tokens/identities/identity.go
@@ -19,9 +19,14 @@ type Claims struct {
 }
 
 func (c *Claims) Sign(rsaKey *rsa.PrivateKey) (string, error) {
+	keyID, err := compat.KeyID(rsaKey.Public())
+	if err != nil {
+		return "", errors.Wrap(err, "KeyID")
+	}
+
 	jwk := jose.JSONWebKey{
 		Key:   rsaKey,
-		KeyID: compat.KeyID(rsaKey.Public()),
+		KeyID: keyID,
 	}
 
 	signer, err := jose.NewSigner(

--- a/tokens/identities/identity_test.go
+++ b/tokens/identities/identity_test.go
@@ -36,6 +36,9 @@ func TestIdentityClaims(t *testing.T) {
 
 		parsed, err := jose.ParseSigned(identityStr)
 		require.NoError(t, err)
-		assert.Equal(t, compat.KeyID(key.Public()), parsed.Signatures[0].Header.KeyID)
+
+		keyID, err := compat.KeyID(key.Public())
+		require.NoError(t, err)
+		assert.Equal(t, keyID, parsed.Signatures[0].Header.KeyID)
 	})
 }


### PR DESCRIPTION
Errors and panics are handled by an `ops.ErrorReporter`. Current implementations include Sentry (enabled with `SENTRY_DSN` ENV variable) and stdout (default).

Each implementation of an `ops.ErrorReporter` is responsible for filtering out sensitive data. This should generally be easy, as sensitive data is transmitted over POST and can be sanely omitted.