### PR TITLE
default ports for Redis and MySQL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,8 +42,8 @@ test:
 # Run CI tests
 .PHONY: ci
 test-ci:
-	TEST_REDIS_URL=redis://127.0.0.1:6379/1 \
-	  TEST_MYSQL_URL=mysql://root@127.0.0.1:3306/test \
+	TEST_REDIS_URL=redis://127.0.0.1/1 \
+	  TEST_MYSQL_URL=mysql://root@127.0.0.1/test \
 	  go test -race $(PKGS)
 
 # Run migrations

--- a/api/app.go
+++ b/api/app.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	raven "github.com/getsentry/raven-go"
-	"github.com/go-redis/redis"
 	"github.com/keratin/authn-server/config"
 	"github.com/keratin/authn-server/data"
 	"github.com/keratin/authn-server/ops"
@@ -43,14 +42,13 @@ func NewApp() (*App, error) {
 
 	db, accountStore, err := data.NewDB(cfg.DatabaseURL)
 	if err != nil {
-		return nil, errors.Wrap(err, "NewDB")
+		return nil, errors.Wrap(err, "data.NewDB")
 	}
 
-	opts, err := redis.ParseURL(cfg.RedisURL.String())
+	redis, err := dataRedis.New(cfg.RedisURL)
 	if err != nil {
-		return nil, errors.Wrap(err, "ParseURL")
+		return nil, errors.Wrap(err, "redis.New")
 	}
-	redis := redis.NewClient(opts)
 
 	tokenStore := &dataRedis.RefreshTokenStore{
 		Client: redis,

--- a/data/mysql/db.go
+++ b/data/mysql/db.go
@@ -50,6 +50,9 @@ func cfgFromURL(url *url.URL) *mysql.Config {
 		Net:    "tcp",
 		Params: map[string]string{"parseTime": "true"},
 	}
+	if url.Port() == "" {
+		cfg.Addr = cfg.Addr + ":3306"
+	}
 	if url.User != nil {
 		cfg.User = url.User.Username()
 		if pwd, ok := url.User.Password(); ok {

--- a/data/redis/db.go
+++ b/data/redis/db.go
@@ -2,10 +2,23 @@ package redis
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 
 	"github.com/go-redis/redis"
+	"github.com/pkg/errors"
 )
+
+func New(url *url.URL) (*redis.Client, error) {
+	opts, err := redis.ParseURL(url.String())
+	if url.Port() == "" {
+		opts.Addr = opts.Addr + ":6379"
+	}
+	if err != nil {
+		return nil, errors.Wrap(err, "ParseURL")
+	}
+	return redis.NewClient(opts), nil
+}
 
 func TestDB() (*redis.Client, error) {
 	str, ok := os.LookupEnv("TEST_REDIS_URL")


### PR DESCRIPTION
Allow ports to be omitted from the connection URLs for Redis and MySQL if they are default values.