### PR TITLE
webhook notification for password changes

### DIFF
--- a/api/passwords/post_password.go
+++ b/api/passwords/post_password.go
@@ -14,6 +14,7 @@ func postPassword(app *api.App) http.HandlerFunc {
 		if r.FormValue("token") != "" {
 			accountID, err = services.PasswordResetter(
 				app.AccountStore,
+				app.Reporter,
 				app.Config,
 				r.FormValue("token"),
 				r.FormValue("password"),
@@ -26,6 +27,7 @@ func postPassword(app *api.App) http.HandlerFunc {
 			}
 			err = services.PasswordChanger(
 				app.AccountStore,
+				app.Reporter,
 				app.Config,
 				accountID,
 				r.FormValue("currentPassword"),

--- a/config/config.go
+++ b/config/config.go
@@ -20,6 +20,7 @@ import (
 
 type Config struct {
 	AppPasswordResetURL    *url.URL
+	AppPasswordChangedURL  *url.URL
 	ApplicationDomains     []Domain
 	BcryptCost             int
 	UsernameIsEmail        bool
@@ -273,12 +274,29 @@ var configurers = []configurer{
 		return nil
 	},
 
+	// APP_PASSWORD_CHANGED_URL is an endpoint that will be notified when an account
+	// has changed its password. This notification may be used to deliver an email
+	// confirmation.
+	//
+	// For security, this URL should specify https and include a basic auth username
+	// and password.
+	func(c *Config) error {
+		if val, ok := os.LookupEnv("APP_PASSWORD_CHANGED_URL"); ok {
+			appURL, err := url.Parse(val)
+			if err != nil {
+				return err
+			}
+			c.AppPasswordChangedURL = appURL
+		}
+		return nil
+	},
+
 	// APP_PASSWORD_RESET_URL is an endpoint that will be notified when an account
 	// has requested a password reset. The endpoint is expected to deliver an email
 	// with the given password reset token, then respond with a 2xx HTTP status.
 	//
-	// For security, this URL should specify https and include a basic auth
-	// username and password.
+	// For security, this URL should specify https and include a basic auth username
+	// and password.
 	func(c *Config) error {
 		if val, ok := os.LookupEnv("APP_PASSWORD_RESET_URL"); ok {
 			resetURL, err := url.Parse(val)

--- a/docs/config.md
+++ b/docs/config.md
@@ -9,7 +9,7 @@ title: Server Configuration
 [`ACCESS_TOKEN_TTL`](#access_token_ttl) • [`REFRESH_TOKEN_TTL`](#refresh_token_ttl) • [`SESSION_KEY_SALT`](#session_key_salt) • [`DB_ENCRYPTION_KEY_SALT`](#db_encryption_key_salt) • [`RSA_PRIVATE_KEY`](#rsa_private_key)
 * Username Policy: [`USERNAME_IS_EMAIL`](#username_is_email) • [`EMAIL_USERNAME_DOMAINS`](#email_username_domains)
 * Password Policy: [`PASSWORD_POLICY_SCORE`](#password_policy_score) • [`BCRYPT_COST`](#bcrypt_cost)
-* Password Resets: [`APP_PASSWORD_RESET_URL`](#app_password_reset_url) • [`PASSWORD_RESET_TOKEN_TTL`](#password_reset_token_ttl)
+* Password Resets: [`APP_PASSWORD_RESET_URL`](#app_password_reset_url) • [`PASSWORD_RESET_TOKEN_TTL`](#password_reset_token_ttl) • [`APP_PASSWORD_CHANGED_URL`](#app_password_changed_url)
 * Stats: [`TIME_ZONE`](#time_zone) • [`DAILY_ACTIVES_RETENTION`](#daily_actives_retention) • [`WEEKLY_ACTIVES_RETENTION`](#weekly_actives_retention)
 * Operations: [`SENTRY_DSN`](#sentry_dsn)
 
@@ -207,6 +207,16 @@ Must be provided to enable password resets. This URL must respond to `POST`, sho
 | Default | 1800 (30.minutes) |
 
 Specifies the amount of time a user has to complete a password reset process. After this period of time, the reset token will no longer be accepted. (Note that a reset token will also be invalidated if the password changes before this TTL.)
+
+### `APP_PASSWORD_CHANGED_URL`
+
+|           |    |
+| --------- | --- |
+| Required? | No |
+| Value | URL |
+| Default | nil |
+
+Must be provided to enable notifications of password changes. This URL must respond to `POST`, should expect to receive an `account_id` param, and is expected to deliver an email confirmation.
 
 ## Stats
 

--- a/services/password_changer.go
+++ b/services/password_changer.go
@@ -3,11 +3,12 @@ package services
 import (
 	"github.com/keratin/authn-server/config"
 	"github.com/keratin/authn-server/data"
+	"github.com/keratin/authn-server/ops"
 	"github.com/pkg/errors"
 	"golang.org/x/crypto/bcrypt"
 )
 
-func PasswordChanger(store data.AccountStore, cfg *config.Config, id int, currentPassword string, password string) error {
+func PasswordChanger(store data.AccountStore, r ops.ErrorReporter, cfg *config.Config, id int, currentPassword string, password string) error {
 	account, err := store.Find(id)
 	if err != nil {
 		return errors.Wrap(err, "Find")
@@ -23,5 +24,5 @@ func PasswordChanger(store data.AccountStore, cfg *config.Config, id int, curren
 		return FieldErrors{{"credentials", ErrFailed}}
 	}
 
-	return PasswordSetter(store, cfg, id, password)
+	return PasswordSetter(store, r, cfg, id, password)
 }

--- a/services/password_changer_test.go
+++ b/services/password_changer_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/keratin/authn-server/config"
 	"github.com/keratin/authn-server/data/mock"
 	"github.com/keratin/authn-server/models"
+	"github.com/keratin/authn-server/ops"
 	"github.com/keratin/authn-server/services"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
@@ -22,7 +23,7 @@ func TestPasswordChanger(t *testing.T) {
 	}
 
 	invoke := func(id int, currentPassword string, password string) error {
-		return services.PasswordChanger(accountStore, cfg, id, currentPassword, password)
+		return services.PasswordChanger(accountStore, &ops.LogReporter{}, cfg, id, currentPassword, password)
 	}
 
 	factory := func(username string, password string) (*models.Account, error) {

--- a/services/password_resetter.go
+++ b/services/password_resetter.go
@@ -3,13 +3,15 @@ package services
 import (
 	"strconv"
 
+	"github.com/keratin/authn-server/ops"
+
 	"github.com/keratin/authn-server/config"
 	"github.com/keratin/authn-server/data"
 	"github.com/keratin/authn-server/tokens/resets"
 	"github.com/pkg/errors"
 )
 
-func PasswordResetter(store data.AccountStore, cfg *config.Config, token string, password string) (int, error) {
+func PasswordResetter(store data.AccountStore, r ops.ErrorReporter, cfg *config.Config, token string, password string) (int, error) {
 	claims, err := resets.Parse(token, cfg)
 	if err != nil {
 		return 0, FieldErrors{{"token", ErrInvalidOrExpired}}
@@ -36,5 +38,5 @@ func PasswordResetter(store data.AccountStore, cfg *config.Config, token string,
 		return 0, FieldErrors{{"token", ErrInvalidOrExpired}}
 	}
 
-	return account.ID, PasswordSetter(store, cfg, id, password)
+	return account.ID, PasswordSetter(store, r, cfg, id, password)
 }

--- a/services/password_resetter_test.go
+++ b/services/password_resetter_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/keratin/authn-server/config"
 	"github.com/keratin/authn-server/data/mock"
+	"github.com/keratin/authn-server/ops"
 	"github.com/keratin/authn-server/services"
 	"github.com/keratin/authn-server/tokens/resets"
 	"github.com/stretchr/testify/assert"
@@ -31,7 +32,7 @@ func TestPasswordResetter(t *testing.T) {
 	}
 
 	invoke := func(token string, password string) error {
-		_, err := services.PasswordResetter(accountStore, cfg, token, password)
+		_, err := services.PasswordResetter(accountStore, &ops.LogReporter{}, cfg, token, password)
 		return err
 	}
 

--- a/services/password_setter.go
+++ b/services/password_setter.go
@@ -22,14 +22,16 @@ func PasswordSetter(store data.AccountStore, r ops.ErrorReporter, cfg *config.Co
 		return errors.Wrap(err, "GenerateFromPassword")
 	}
 
-	go func() {
-		err := WebhookSender(cfg.AppPasswordChangedURL, &url.Values{
-			"account_id": []string{strconv.Itoa(accountID)},
-		})
-		if err != nil {
-			r.ReportError(err)
-		}
-	}()
+	if cfg.AppPasswordChangedURL != nil {
+		go func() {
+			err := WebhookSender(cfg.AppPasswordChangedURL, &url.Values{
+				"account_id": []string{strconv.Itoa(accountID)},
+			})
+			if err != nil {
+				r.ReportError(err)
+			}
+		}()
+	}
 
 	return store.SetPassword(accountID, hash)
 }

--- a/services/password_setter.go
+++ b/services/password_setter.go
@@ -1,13 +1,17 @@
 package services
 
 import (
+	"net/url"
+	"strconv"
+
 	"github.com/keratin/authn-server/config"
 	"github.com/keratin/authn-server/data"
+	"github.com/keratin/authn-server/ops"
 	"github.com/pkg/errors"
 	"golang.org/x/crypto/bcrypt"
 )
 
-func PasswordSetter(store data.AccountStore, cfg *config.Config, accountID int, password string) error {
+func PasswordSetter(store data.AccountStore, r ops.ErrorReporter, cfg *config.Config, accountID int, password string) error {
 	fieldError := passwordValidator(cfg, password)
 	if fieldError != nil {
 		return FieldErrors{*fieldError}
@@ -17,6 +21,15 @@ func PasswordSetter(store data.AccountStore, cfg *config.Config, accountID int, 
 	if err != nil {
 		return errors.Wrap(err, "GenerateFromPassword")
 	}
+
+	go func() {
+		err := WebhookSender(cfg.AppPasswordChangedURL, &url.Values{
+			"account_id": []string{strconv.Itoa(accountID)},
+		})
+		if err != nil {
+			r.ReportError(err)
+		}
+	}()
 
 	return store.SetPassword(accountID, hash)
 }

--- a/services/password_setter_test.go
+++ b/services/password_setter_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/keratin/authn-server/config"
 	"github.com/keratin/authn-server/data/mock"
+	"github.com/keratin/authn-server/ops"
 	"github.com/keratin/authn-server/services"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -18,7 +19,7 @@ func TestPasswordSetter(t *testing.T) {
 	}
 
 	invoke := func(id int, password string) error {
-		return services.PasswordSetter(accountStore, cfg, id, password)
+		return services.PasswordSetter(accountStore, &ops.LogReporter{}, cfg, id, password)
 	}
 
 	account, err := accountStore.Create("existing@keratin.tech", []byte("old"))

--- a/services/webhook_sender.go
+++ b/services/webhook_sender.go
@@ -1,0 +1,29 @@
+package services
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/pkg/errors"
+)
+
+func WebhookSender(destination *url.URL, values *url.Values) error {
+	if destination == nil {
+		return fmt.Errorf("URL unconfigured")
+	}
+
+	res, err := http.PostForm(destination.String(), *values)
+	if err != nil {
+		if urlErr, ok := err.(*url.Error); ok {
+			// avoid reporting the URL with potential HTTP auth credentials
+			return errors.Wrap(urlErr.Err, "PostForm")
+		}
+		return errors.Wrap(err, "PostForm")
+	}
+	if res.StatusCode > 299 {
+		return fmt.Errorf("Status Code: %v", res.StatusCode)
+	}
+
+	return nil
+}

--- a/services/webhook_sender_test.go
+++ b/services/webhook_sender_test.go
@@ -1,0 +1,54 @@
+package services_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/keratin/authn-server/services"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWebhookSender(t *testing.T) {
+	remoteApp := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		u, p, ok := r.BasicAuth()
+
+		if !ok || u != "user" || p != "pass" {
+			w.WriteHeader(http.StatusUnauthorized)
+		} else if r.URL.Path == "/success" {
+			w.WriteHeader(http.StatusOK)
+		} else if r.URL.Path == "/failure" {
+			w.WriteHeader(http.StatusInternalServerError)
+		} else {
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	serverURL, err := url.Parse(remoteApp.URL)
+	require.NoError(t, err)
+
+	unauthedURL := &url.URL{Scheme: "http", Host: serverURL.Host, Path: "/success"}
+	successURL := &url.URL{Scheme: "http", Host: serverURL.Host, Path: "/success", User: url.UserPassword("user", "pass")}
+	failureURL := &url.URL{Scheme: "http", Host: serverURL.Host, Path: "/failure", User: url.UserPassword("user", "pass")}
+
+	t.Run("posting to remote app", func(t *testing.T) {
+		err := services.WebhookSender(successURL, &url.Values{})
+		assert.NoError(t, err)
+	})
+
+	t.Run("without auth", func(t *testing.T) {
+		err := services.WebhookSender(unauthedURL, &url.Values{})
+		assert.Equal(t, "Status Code: 401", err.Error())
+	})
+
+	t.Run("without configured url", func(t *testing.T) {
+		err := services.WebhookSender(nil, &url.Values{})
+		assert.Equal(t, "URL unconfigured", err.Error())
+	})
+
+	t.Run("with remote app failure", func(t *testing.T) {
+		err := services.WebhookSender(failureURL, &url.Values{})
+		assert.Equal(t, "Status Code: 500", err.Error())
+	})
+}


### PR DESCRIPTION
When an account password is changed or reset, AuthN can optionally deliver a notification to the endpoint indicated by `APP_PASSWORD_CHANGED_URL`.