### PR TITLE
revoke logins when archiving and locking accounts

### DIFF
--- a/api/accounts/delete_account.go
+++ b/api/accounts/delete_account.go
@@ -17,7 +17,7 @@ func deleteAccount(app *api.App) http.HandlerFunc {
 			return
 		}
 
-		err = services.AccountArchiver(app.AccountStore, id)
+		err = services.AccountArchiver(app.AccountStore, app.RefreshTokenStore, id)
 		if err != nil {
 			if _, ok := err.(services.FieldErrors); ok {
 				api.WriteNotFound(w, "account")

--- a/api/accounts/patch_account_lock.go
+++ b/api/accounts/patch_account_lock.go
@@ -17,7 +17,7 @@ func patchAccountLock(app *api.App) http.HandlerFunc {
 			return
 		}
 
-		err = services.AccountLocker(app.AccountStore, id)
+		err = services.AccountLocker(app.AccountStore, app.RefreshTokenStore, id)
 		if err != nil {
 			if _, ok := err.(services.FieldErrors); ok {
 				api.WriteNotFound(w, "account")

--- a/services/account_archiver.go
+++ b/services/account_archiver.go
@@ -5,13 +5,24 @@ import (
 	"github.com/pkg/errors"
 )
 
-func AccountArchiver(store data.AccountStore, accountID int) error {
+func AccountArchiver(store data.AccountStore, tokenStore data.RefreshTokenStore, accountID int) error {
 	account, err := store.Find(accountID)
 	if err != nil {
 		return errors.Wrap(err, "Find")
 	}
 	if account == nil {
 		return FieldErrors{{"account", ErrNotFound}}
+	}
+
+	tokens, err := tokenStore.FindAll(accountID)
+	if err != nil {
+		return errors.Wrap(err, "FindAll")
+	}
+	for _, token := range tokens {
+		err = tokenStore.Revoke(token)
+		if err != nil {
+			return errors.Wrap(err, "Revoke")
+		}
 	}
 
 	return store.Archive(account.ID)

--- a/services/account_locker.go
+++ b/services/account_locker.go
@@ -5,13 +5,24 @@ import (
 	"github.com/pkg/errors"
 )
 
-func AccountLocker(store data.AccountStore, accountID int) error {
+func AccountLocker(store data.AccountStore, tokenStore data.RefreshTokenStore, accountID int) error {
 	account, err := store.Find(accountID)
 	if err != nil {
 		return errors.Wrap(err, "Find")
 	}
 	if account == nil {
 		return FieldErrors{{"account", ErrNotFound}}
+	}
+
+	tokens, err := tokenStore.FindAll(accountID)
+	if err != nil {
+		return errors.Wrap(err, "FindAll")
+	}
+	for _, token := range tokens {
+		err = tokenStore.Revoke(token)
+		if err != nil {
+			return errors.Wrap(err, "Revoke")
+		}
 	}
 
 	return store.Lock(account.ID)

--- a/services/account_locker_test.go
+++ b/services/account_locker_test.go
@@ -10,16 +10,16 @@ import (
 )
 
 func TestAccountLocker(t *testing.T) {
-	store := mock.NewAccountStore()
+	accountStore := mock.NewAccountStore()
 	refreshStore := mock.NewRefreshTokenStore()
 
 	t.Run("logged in account", func(t *testing.T) {
-		account, err := store.Create("loggedin@keratin.tech", []byte("password"))
+		account, err := accountStore.Create("loggedin@keratin.tech", []byte("password"))
 		require.NoError(t, err)
 		token1, err := refreshStore.Create(account.ID)
 		require.NoError(t, err)
 
-		errs := services.AccountLocker(store, refreshStore, account.ID)
+		errs := services.AccountLocker(accountStore, refreshStore, account.ID)
 		assert.Empty(t, errs)
 
 		id, err := refreshStore.Find(token1)
@@ -28,33 +28,33 @@ func TestAccountLocker(t *testing.T) {
 	})
 
 	t.Run("locked account", func(t *testing.T) {
-		account, err := store.Create("locked@keratin.tech", []byte("password"))
+		account, err := accountStore.Create("locked@keratin.tech", []byte("password"))
 		require.NoError(t, err)
-		err = store.Lock(account.ID)
+		err = accountStore.Lock(account.ID)
 		require.NoError(t, err)
 
-		errs := services.AccountLocker(store, refreshStore, account.ID)
+		errs := services.AccountLocker(accountStore, refreshStore, account.ID)
 		assert.Empty(t, errs)
 
-		acct, err := store.Find(account.ID)
+		acct, err := accountStore.Find(account.ID)
 		require.NoError(t, err)
 		assert.True(t, acct.Locked)
 	})
 
 	t.Run("unlocked account", func(t *testing.T) {
-		account, err := store.Create("unlocked@keratin.tech", []byte("password"))
+		account, err := accountStore.Create("unlocked@keratin.tech", []byte("password"))
 		require.NoError(t, err)
 
-		errs := services.AccountLocker(store, refreshStore, account.ID)
+		errs := services.AccountLocker(accountStore, refreshStore, account.ID)
 		assert.Empty(t, errs)
 
-		acct, err := store.Find(account.ID)
+		acct, err := accountStore.Find(account.ID)
 		require.NoError(t, err)
 		assert.True(t, acct.Locked)
 	})
 
 	t.Run("unknown account", func(t *testing.T) {
-		errs := services.AccountLocker(store, refreshStore, 123456789)
+		errs := services.AccountLocker(accountStore, refreshStore, 123456789)
 		assert.Equal(t, services.FieldErrors{{"account", services.ErrNotFound}}, errs)
 	})
 }

--- a/services/account_locker_test.go
+++ b/services/account_locker_test.go
@@ -11,33 +11,50 @@ import (
 
 func TestAccountLocker(t *testing.T) {
 	store := mock.NewAccountStore()
+	refreshStore := mock.NewRefreshTokenStore()
 
-	lockedAccount, err := store.Create("locked@keratin.tech", []byte("password"))
-	require.NoError(t, err)
-	err = store.Lock(lockedAccount.ID)
-	require.NoError(t, err)
+	t.Run("logged in account", func(t *testing.T) {
+		account, err := store.Create("loggedin@keratin.tech", []byte("password"))
+		require.NoError(t, err)
+		token1, err := refreshStore.Create(account.ID)
+		require.NoError(t, err)
 
-	unlockedAccount, err := store.Create("unlocked@keratin.tech", []byte("password"))
-	require.NoError(t, err)
+		errs := services.AccountLocker(store, refreshStore, account.ID)
+		assert.Empty(t, errs)
 
-	var testCases = []struct {
-		accountID int
-		errors    *services.FieldErrors
-	}{
-		{123456789, &services.FieldErrors{{"account", services.ErrNotFound}}},
-		{lockedAccount.ID, nil},
-		{unlockedAccount.ID, nil},
-	}
+		id, err := refreshStore.Find(token1)
+		require.NoError(t, err)
+		assert.Empty(t, id)
+	})
 
-	for _, tc := range testCases {
-		errs := services.AccountLocker(store, tc.accountID)
-		if tc.errors == nil {
-			assert.Empty(t, errs)
-			acct, err := store.Find(tc.accountID)
-			require.NoError(t, err)
-			assert.True(t, acct.Locked)
-		} else {
-			assert.Equal(t, *tc.errors, errs)
-		}
-	}
+	t.Run("locked account", func(t *testing.T) {
+		account, err := store.Create("locked@keratin.tech", []byte("password"))
+		require.NoError(t, err)
+		err = store.Lock(account.ID)
+		require.NoError(t, err)
+
+		errs := services.AccountLocker(store, refreshStore, account.ID)
+		assert.Empty(t, errs)
+
+		acct, err := store.Find(account.ID)
+		require.NoError(t, err)
+		assert.True(t, acct.Locked)
+	})
+
+	t.Run("unlocked account", func(t *testing.T) {
+		account, err := store.Create("unlocked@keratin.tech", []byte("password"))
+		require.NoError(t, err)
+
+		errs := services.AccountLocker(store, refreshStore, account.ID)
+		assert.Empty(t, errs)
+
+		acct, err := store.Find(account.ID)
+		require.NoError(t, err)
+		assert.True(t, acct.Locked)
+	})
+
+	t.Run("unknown account", func(t *testing.T) {
+		errs := services.AccountLocker(store, refreshStore, 123456789)
+		assert.Equal(t, services.FieldErrors{{"account", services.ErrNotFound}}, errs)
+	})
 }


### PR DESCRIPTION
Archived and locked accounts may not log in. Therefore, they should not remain logged in.