### PR TITLE
add: `GET /metrics` (authenticated)

### DIFF
--- a/api/meta/routing.go
+++ b/api/meta/routing.go
@@ -3,6 +3,7 @@ package meta
 import (
 	"github.com/keratin/authn-server/api"
 	"github.com/keratin/authn-server/lib/route"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 func Routes(app *api.App) []*route.HandledRoute {
@@ -24,5 +25,8 @@ func Routes(app *api.App) []*route.HandledRoute {
 		route.Get("/stats").
 			SecuredWith(authentication).
 			Handle(getStats(app)),
+		route.Get("/metrics").
+			SecuredWith(authentication).
+			Handle(promhttp.Handler()),
 	}
 }

--- a/api/views/root.ego
+++ b/api/views/root.ego
@@ -14,7 +14,8 @@ func Root(w io.Writer) {
       <div style="flex: 1 0 auto;">
         <ul>
           <li><a href="health">Health</a></li>
-          <li><a href="stats">Stats</a></li>
+          <li><a href="stats">Active Users</a></li>
+          <li><a href="metrics">Server Metrics</a></li>
           <li><a href="jwks">Keys</a></li>
           <li><a href="https://github.com/keratin/authn-server">GitHub</a></li>
           <li><a href="https://github.com/keratin/authn-server/blob/master/docs/README.md">Docs</a></li>

--- a/docs/api.md
+++ b/docs/api.md
@@ -481,7 +481,7 @@ This endpoint is primarily used by backend client libraries to fetch the public 
 
 ### Service Stats
 
-Visibility: Public
+Visibility: Private
 
 `GET /stats`
 
@@ -506,3 +506,23 @@ Time periods are labeled in ISO8601 formats:
         "monthly": {}
       }
     }
+
+### Server Stats
+
+Visibility: Private
+
+`GET /metrics`
+
+Returns server stats (memory usage) and traffic stats (counts, timings) that may be used to monitor and alert on server health. The data is formatted for consumption by Prometheus-compatible collectors.
+
+#### Success:
+
+    200 Ok
+
+    # HELP go_goroutines Number of goroutines that currently exist.
+    # TYPE go_goroutines gauge
+    go_goroutines 10
+    [...]
+    # HELP http_requests_total How many HTTP requests processed, partitioned by name and status code
+    # TYPE http_requests_total counter
+    http_requests_total{code="200",name="GET /health"} 97

--- a/glide.lock
+++ b/glide.lock
@@ -1,6 +1,10 @@
-hash: 635cdba30635229b8c7eceb94e5e8d9ca1fd680622cb73b2eb3daf2fd712d47f
-updated: 2017-10-06T16:28:29.774912928-07:00
+hash: b26eff5066cc5f7b9adf595573ae694ca85dc89f590ae1c9ac070942220ba121
+updated: 2017-11-10T10:36:35.394427-08:00
 imports:
+- name: github.com/beorn7/perks
+  version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
+  subpackages:
+  - quantile
 - name: github.com/certifi/gocertifi
   version: 3fd9e1adb12b72d2f3f82191d49be9b93c69f67c
 - name: github.com/davecgh/go-spew
@@ -10,7 +14,7 @@ imports:
 - name: github.com/getsentry/raven-go
   version: d175f85701dfbf44cb0510114c9943e665e60907
 - name: github.com/go-redis/redis
-  version: 8e6b51ec3a92ec095dcbd2439c7a3eec6b6cb586
+  version: d0f86971b5d61de9cebd2616b932acb7ba14d957
   subpackages:
   - internal
   - internal/consistenthash
@@ -19,12 +23,16 @@ imports:
   - internal/proto
 - name: github.com/go-sql-driver/mysql
   version: a0583e0143b1624142adab07e0e97fe106d99561
+- name: github.com/golang/protobuf
+  version: 1643683e1b54a9e88ad26d98f81400c8c9d9f4f9
+  subpackages:
+  - proto
 - name: github.com/gorilla/context
   version: 08b5f424b9271eedf6f9f0ce86cb9396ed337a42
 - name: github.com/gorilla/handlers
-  version: a4043c62cc2329bacda331d33fc908ab11ef0ec3
+  version: 90663712d74cb411cbef281bc1e08c19d1a76145
 - name: github.com/gorilla/mux
-  version: 24fca303ac6da784b9e8269f724ddeb0b2eea5e7
+  version: 7f08801859139f86dfafd1c296e2cba9a80d292e
 - name: github.com/jmoiron/sqlx
   version: d9bd385d68c068f1fabb5057e3dedcbcbb039d0f
   subpackages:
@@ -34,7 +42,11 @@ imports:
   subpackages:
   - autoload
 - name: github.com/mattn/go-sqlite3
-  version: ca5e3819723d8eeaf170ad510e7da1d6d2e94a08
+  version: 5160b48509cf5c877bc22c11c373f8c7738cdb38
+- name: github.com/matttproud/golang_protobuf_extensions
+  version: c12348ce28de40eed0136aa2b644d0ee0650e56c
+  subpackages:
+  - pbutil
 - name: github.com/nbutton23/zxcvbn-go
   version: a22cb81b2ecdde8b68e9ffb8824731cbf88e1de4
   subpackages:
@@ -52,6 +64,24 @@ imports:
   version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
   - difflib
+- name: github.com/prometheus/client_golang
+  version: 967789050ba94deca04a5e84cce8ad472ce313c1
+  subpackages:
+  - prometheus
+- name: github.com/prometheus/client_model
+  version: 6f3806018612930941127f2a7c6c453ba2c527d2
+  subpackages:
+  - go
+- name: github.com/prometheus/common
+  version: e3fb1a1acd7605367a2b378bc2e2f893c05174b7
+  subpackages:
+  - expfmt
+  - internal/bitbucket.org/ww/goautoneg
+  - model
+- name: github.com/prometheus/procfs
+  version: a6e9df898b1336106c743392c48ee0b71f5c4efa
+  subpackages:
+  - xfs
 - name: github.com/sirupsen/logrus
   version: f006c2ac4710855cf0f916dd6b77acf6b048dc6e
 - name: github.com/square/go-jose

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: b26eff5066cc5f7b9adf595573ae694ca85dc89f590ae1c9ac070942220ba121
-updated: 2017-11-10T10:36:35.394427-08:00
+hash: 2c494641d330e16d311509951079f72ac08a45e8fe3d458bc68219bc9ef48ac1
+updated: 2017-11-10T12:14:21.042279-08:00
 imports:
 - name: github.com/beorn7/perks
   version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
@@ -11,6 +11,8 @@ imports:
   version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
   subpackages:
   - spew
+- name: github.com/felixge/httpsnoop
+  version: eadd4fad6aac69ae62379194fe0219f3dbc80fd3
 - name: github.com/getsentry/raven-go
   version: d175f85701dfbf44cb0510114c9943e665e60907
 - name: github.com/go-redis/redis
@@ -68,6 +70,7 @@ imports:
   version: 967789050ba94deca04a5e84cce8ad472ce313c1
   subpackages:
   - prometheus
+  - prometheus/promhttp
 - name: github.com/prometheus/client_model
   version: 6f3806018612930941127f2a7c6c453ba2c527d2
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -29,3 +29,7 @@ import:
 - package: github.com/getsentry/raven-go
 - package: github.com/sirupsen/logrus
   version: ^1.0.3
+- package: github.com/prometheus/client_golang
+  version: ^0.9.0-pre1
+  subpackages:
+  - prometheus

--- a/glide.yaml
+++ b/glide.yaml
@@ -33,3 +33,4 @@ import:
   version: ^0.9.0-pre1
   subpackages:
   - prometheus
+- package: github.com/felixge/httpsnoop

--- a/lib/route/instrument.go
+++ b/lib/route/instrument.go
@@ -1,0 +1,41 @@
+package route
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/felixge/httpsnoop"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	httpRequests = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "http_requests_total",
+			Help: "How many HTTP requests processed, partitioned by name and status code",
+		},
+		[]string{"name", "code"},
+	)
+	httpTimings = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "http_request_times",
+			Help:    "The duration of HTTP requests, partitioned by name",
+			Buckets: prometheus.ExponentialBuckets(0.001, 10, 5),
+		},
+		[]string{"name"},
+	)
+)
+
+func init() {
+	prometheus.MustRegister(httpRequests)
+	prometheus.MustRegister(httpTimings)
+}
+
+func instrumentRoute(name string, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		metrics := httpsnoop.CaptureMetrics(next, w, r)
+		httpRequests.WithLabelValues(name, strconv.Itoa(metrics.Code)).Inc()
+		httpTimings.WithLabelValues(name).Observe(float64(metrics.Duration.Seconds()))
+	})
+}

--- a/lib/route/route.go
+++ b/lib/route/route.go
@@ -71,6 +71,6 @@ func Attach(router *mux.Router, pathPrefix string, routes ...*HandledRoute) {
 			PathPrefix(pathPrefix).
 			Methods(r.verb).
 			Path(r.tpl).
-			Handler(r.security(r.handler))
+			Handler(instrumentRoute(r.verb+" "+r.tpl, r.security(r.handler)))
 	}
 }


### PR DESCRIPTION
This change uses the Prometheus Go client to collect and expose metrics including:

* server stats (e.g. memory usage)
* traffic stats (e.g. counts and timings of requests, by verb+path)

Reasons:

1. I've opted to publish consumable stats (rather than push them) because it can be done without any extra configuration of the AuthN service.
2. The consumable stats are in Prometheus' data format, because the Prometheus Go client is pretty nice and because alternative offerings such as InfluxDB have begun offering to [read Prometheus data](https://www.influxdata.com/blog/monitoring-with-push-vs-pull-influxdb-adds-pull-support-with-kapacitor/).