### PR TITLE
sqlite3 implementations of BlobStore and RefreshTokenStore

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,15 @@ test-ci:
 	  TEST_MYSQL_URL=mysql://root@127.0.0.1/test \
 	  go test -race $(PKGS)
 
+# Run benchmarks
+.PHONY: benchmarks
+benchmarks:
+	docker-compose up -d redis
+	TEST_REDIS_URL=redis://127.0.0.1:8701/12 \
+		go test -run=XXX -bench=. \
+			github.com/keratin/authn-server/api/meta \
+			github.com/keratin/authn-server/api/sessions
+
 # Run migrations
 .PHONY: migrate
 migrate:

--- a/api/app.go
+++ b/api/app.go
@@ -44,7 +44,7 @@ func NewApp() (*App, error) {
 		reporter = &ops.LogReporter{}
 	}
 
-	db, accountStore, err := data.NewDB(cfg.DatabaseURL)
+	db, err := data.NewDB(cfg.DatabaseURL)
 	if err != nil {
 		return nil, errors.Wrap(err, "data.NewDB")
 	}
@@ -54,9 +54,14 @@ func NewApp() (*App, error) {
 		return nil, errors.Wrap(err, "redis.New")
 	}
 
-	tokenStore := &dataRedis.RefreshTokenStore{
-		Client: redis,
-		TTL:    cfg.RefreshTokenTTL,
+	accountStore := data.NewAccountStore(db)
+	if accountStore == nil {
+		return nil, errors.Wrap(err, "NewAccountStore")
+	}
+
+	tokenStore := data.NewRefreshTokenStore(db, redis, cfg.RefreshTokenTTL)
+	if tokenStore == nil {
+		return nil, errors.Wrap(err, "NewRefreshTokenStore")
 	}
 
 	keyStore := data.NewRotatingKeyStore()

--- a/api/app.go
+++ b/api/app.go
@@ -59,7 +59,7 @@ func NewApp() (*App, error) {
 		return nil, errors.Wrap(err, "NewAccountStore")
 	}
 
-	tokenStore := data.NewRefreshTokenStore(db, redis, cfg.RefreshTokenTTL)
+	tokenStore := data.NewRefreshTokenStore(db, redis, reporter, cfg.RefreshTokenTTL)
 	if tokenStore == nil {
 		return nil, errors.Wrap(err, "NewRefreshTokenStore")
 	}

--- a/api/app.go
+++ b/api/app.go
@@ -68,7 +68,7 @@ func NewApp() (*App, error) {
 	if cfg.IdentitySigningKey == nil {
 		m := data.NewKeyStoreRotater(
 			data.NewEncryptedBlobStore(
-				data.NewBlobStore(cfg.AccessTokenTTL, redis),
+				data.NewBlobStore(cfg.AccessTokenTTL, redis, db, reporter),
 				cfg.DBEncryptionKey,
 			),
 			cfg.AccessTokenTTL,

--- a/api/sessions/get_session_refresh_test.go
+++ b/api/sessions/get_session_refresh_test.go
@@ -20,6 +20,15 @@ import (
 )
 
 func BenchmarkGetSessionRefresh(b *testing.B) {
+	verify := func(res *http.Response, err error) {
+		if err != nil {
+			panic(err)
+		}
+		if res.StatusCode != http.StatusCreated {
+			panic(res.StatusCode)
+		}
+	}
+
 	b.Run("mock    store", func(b *testing.B) {
 		app := test.App()
 		server := test.Server(app, apiSessions.Routes(app))
@@ -31,7 +40,7 @@ func BenchmarkGetSessionRefresh(b *testing.B) {
 
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			client.Get("/session/refresh")
+			verify(client.Get("/session/refresh"))
 		}
 	})
 
@@ -52,7 +61,7 @@ func BenchmarkGetSessionRefresh(b *testing.B) {
 
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			client.Get("/session/refresh")
+			verify(client.Get("/session/refresh"))
 		}
 	})
 
@@ -72,7 +81,7 @@ func BenchmarkGetSessionRefresh(b *testing.B) {
 
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			client.Get("/session/refresh")
+			verify(client.Get("/session/refresh"))
 		}
 	})
 }

--- a/api/sessions/get_session_refresh_test.go
+++ b/api/sessions/get_session_refresh_test.go
@@ -4,17 +4,78 @@ import (
 	"net/http"
 	"net/url"
 	"testing"
+	"time"
 
 	"github.com/keratin/authn-server/api"
 	apiSessions "github.com/keratin/authn-server/api/sessions"
 	"github.com/keratin/authn-server/api/test"
 	"github.com/keratin/authn-server/config"
 	"github.com/keratin/authn-server/data/mock"
+	"github.com/keratin/authn-server/data/redis"
+	"github.com/keratin/authn-server/data/sqlite3"
 	"github.com/keratin/authn-server/lib/route"
 	"github.com/keratin/authn-server/ops"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func BenchmarkGetSessionRefresh(b *testing.B) {
+	b.Run("mock    store", func(b *testing.B) {
+		app := test.App()
+		server := test.Server(app, apiSessions.Routes(app))
+		defer server.Close()
+		app.RefreshTokenStore = mock.NewRefreshTokenStore()
+		client := route.NewClient(server.URL).
+			Referred(&app.Config.ApplicationDomains[0]).
+			WithCookie(test.CreateSession(app.RefreshTokenStore, app.Config, 12345))
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			client.Get("/session/refresh")
+		}
+	})
+
+	sqliteDB, err := sqlite3.NewDB("benchmarks")
+	if err != nil {
+		panic(err)
+	}
+	sqlite3.MigrateDB(sqliteDB)
+
+	b.Run("sqlite3 store", func(b *testing.B) {
+		app := test.App()
+		server := test.Server(app, apiSessions.Routes(app))
+		defer server.Close()
+		app.RefreshTokenStore = &sqlite3.RefreshTokenStore{sqliteDB, time.Hour}
+		client := route.NewClient(server.URL).
+			Referred(&app.Config.ApplicationDomains[0]).
+			WithCookie(test.CreateSession(app.RefreshTokenStore, app.Config, 12345))
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			client.Get("/session/refresh")
+		}
+	})
+
+	redisDB, err := redis.TestDB()
+	if err != nil {
+		panic(err)
+	}
+
+	b.Run("redis   store", func(b *testing.B) {
+		app := test.App()
+		server := test.Server(app, apiSessions.Routes(app))
+		defer server.Close()
+		app.RefreshTokenStore = &redis.RefreshTokenStore{redisDB, time.Hour}
+		client := route.NewClient(server.URL).
+			Referred(&app.Config.ApplicationDomains[0]).
+			WithCookie(test.CreateSession(app.RefreshTokenStore, app.Config, 12345))
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			client.Get("/session/refresh")
+		}
+	})
+}
 
 func TestGetSessionRefreshSuccess(t *testing.T) {
 	app := test.App()

--- a/data/account_store.go
+++ b/data/account_store.go
@@ -1,6 +1,11 @@
 package data
 
-import "github.com/keratin/authn-server/models"
+import (
+	"github.com/jmoiron/sqlx"
+	"github.com/keratin/authn-server/data/mysql"
+	"github.com/keratin/authn-server/data/sqlite3"
+	"github.com/keratin/authn-server/models"
+)
 
 type AccountStore interface {
 	Create(u string, p []byte) (*models.Account, error)
@@ -12,4 +17,15 @@ type AccountStore interface {
 	RequireNewPassword(id int) error
 	SetPassword(id int, p []byte) error
 	UpdateUsername(id int, u string) error
+}
+
+func NewAccountStore(db *sqlx.DB) AccountStore {
+	switch db.DriverName() {
+	case "sqlite3":
+		return &sqlite3.AccountStore{DB: db}
+	case "mysql":
+		return &mysql.AccountStore{DB: db}
+	default:
+		return nil
+	}
 }

--- a/data/blob_store.go
+++ b/data/blob_store.go
@@ -4,7 +4,10 @@ import (
 	"time"
 
 	"github.com/go-redis/redis"
+	"github.com/jmoiron/sqlx"
 	dataRedis "github.com/keratin/authn-server/data/redis"
+	"github.com/keratin/authn-server/data/sqlite3"
+	"github.com/keratin/authn-server/ops"
 )
 
 type BlobStore interface {
@@ -19,13 +22,32 @@ type BlobStore interface {
 	Write(name string, blob []byte) error
 }
 
-func NewBlobStore(interval time.Duration, redis *redis.Client) BlobStore {
-	return &dataRedis.BlobStore{
-		// the lifetime of a key should be slightly more than two intervals
-		TTL: interval*2 + 10*time.Second,
-		// the write lock should be greater than the peak time necessary to generate and
-		// encrypt a key, plus send it back over the wire to redis.
-		LockTime: time.Duration(500) * time.Millisecond,
-		Client:   redis,
+func NewBlobStore(interval time.Duration, redis *redis.Client, db *sqlx.DB, reporter ops.ErrorReporter) BlobStore {
+	// the lifetime of a key should be slightly more than two intervals
+	ttl := interval*2 + 10*time.Second
+
+	// the write lock should be greater than the peak time necessary to generate and
+	// encrypt a key, plus send it back over the wire to redis.
+	lockTime := time.Duration(500) * time.Millisecond
+
+	if redis != nil {
+		return &dataRedis.BlobStore{
+			TTL:      ttl,
+			LockTime: lockTime,
+			Client:   redis,
+		}
+	}
+
+	switch db.DriverName() {
+	case "sqlite3":
+		store := &sqlite3.BlobStore{
+			TTL:      ttl,
+			LockTime: lockTime,
+			DB:       db,
+		}
+		store.Clean(reporter)
+		return store
+	default:
+		return nil
 	}
 }

--- a/data/data.go
+++ b/data/data.go
@@ -12,25 +12,15 @@ import (
 	sq3 "github.com/mattn/go-sqlite3"
 )
 
-func NewDB(url *url.URL) (*sqlx.DB, AccountStore, error) {
+func NewDB(url *url.URL) (*sqlx.DB, error) {
 	switch url.Scheme {
 	case "sqlite3":
-		db, err := sqlite3.NewDB(url.Path)
-		if err != nil {
-			return nil, nil, err
-		}
-		store := sqlite3.AccountStore{db}
-		return db, &store, nil
+		return sqlite3.NewDB(url.Path)
 	case "mysql", "mysql2":
 		// mysql2 is compatibility with the ruby version, where it is the name of a popular driver
-		db, err := mysql.NewDB(url)
-		if err != nil {
-			return nil, nil, err
-		}
-		store := mysql.AccountStore{db}
-		return db, &store, nil
+		return mysql.NewDB(url)
 	default:
-		return nil, nil, fmt.Errorf("Unsupported database: %s", url.Scheme)
+		return nil, fmt.Errorf("Unsupported database: %s", url.Scheme)
 	}
 }
 

--- a/data/refresh_token_store.go
+++ b/data/refresh_token_store.go
@@ -1,6 +1,14 @@
 package data
 
-import "github.com/keratin/authn-server/models"
+import (
+	"time"
+
+	"github.com/go-redis/redis"
+	"github.com/jmoiron/sqlx"
+	dataRedis "github.com/keratin/authn-server/data/redis"
+	"github.com/keratin/authn-server/data/sqlite3"
+	"github.com/keratin/authn-server/models"
+)
 
 type RefreshTokenStore interface {
 	// Generates and persists a token for the given accountID.
@@ -23,4 +31,23 @@ type RefreshTokenStore interface {
 	// Revokes the token and removes it from the set of active tokens for the account. Doesn't error
 	// if the token is unknown or already revoked.
 	Revoke(t models.RefreshToken) error
+}
+
+func NewRefreshTokenStore(db *sqlx.DB, redis *redis.Client, ttl time.Duration) RefreshTokenStore {
+	if redis != nil {
+		return &dataRedis.RefreshTokenStore{
+			Client: redis,
+			TTL:    ttl,
+		}
+	}
+
+	switch db.DriverName() {
+	case "sqlite3":
+		return &sqlite3.RefreshTokenStore{
+			DB:  db,
+			TTL: ttl,
+		}
+	default:
+		return nil
+	}
 }

--- a/data/refresh_token_store_test.go
+++ b/data/refresh_token_store_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/keratin/authn-server/data"
 	"github.com/keratin/authn-server/data/mock"
 	"github.com/keratin/authn-server/data/redis"
+	"github.com/keratin/authn-server/data/sqlite3"
 	"github.com/keratin/authn-server/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -21,20 +22,35 @@ func TestRefreshTokenStore(t *testing.T) {
 		testRefreshTokenRevoke,
 	}
 
-	for _, tester := range testers {
-		store := mock.NewRefreshTokenStore()
-		tester(t, store)
-	}
+	t.Run("Mock", func(t *testing.T) {
+		for _, tester := range testers {
+			store := mock.NewRefreshTokenStore()
+			tester(t, store)
+		}
+	})
 
-	client, err := redis.TestDB()
-	require.NoError(t, err)
-	store := &redis.RefreshTokenStore{Client: client, TTL: time.Second}
-	for _, tester := range testers {
-		tester(t, store)
-		store.FlushDb()
-	}
+	t.Run("Redis", func(t *testing.T) {
+		client, err := redis.TestDB()
+		require.NoError(t, err)
+		store := &redis.RefreshTokenStore{Client: client, TTL: time.Second}
+		for _, tester := range testers {
+			tester(t, store)
+			store.FlushDb()
+		}
+	})
+
+	t.Run("Sqlite3", func(t *testing.T) {
+		for _, tester := range testers {
+			db, err := sqlite3.TestDB()
+			require.NoError(t, err)
+			store := &sqlite3.RefreshTokenStore{db, time.Second}
+			tester(t, store)
+			store.Close()
+		}
+	})
 }
 
+// TODO: find way to test that expired tokens are not found
 func testRefreshTokenFind(t *testing.T, store data.RefreshTokenStore) {
 	// finding nothing
 	id, err := store.Find(models.RefreshToken("a1b2c3"))
@@ -51,11 +67,13 @@ func testRefreshTokenFind(t *testing.T, store data.RefreshTokenStore) {
 	}
 }
 
+// TODO: find way to test for not touching expired tokens
 func testRefreshTokenTouch(t *testing.T, store data.RefreshTokenStore) {
 	err := store.Touch(models.RefreshToken("a1b2c3"), 123)
 	assert.NoError(t, err)
 }
 
+// TODO: find way to test for not finding expired tokens
 func testRefreshTokenFindAll(t *testing.T, store data.RefreshTokenStore) {
 	id := 123
 

--- a/data/sqlite3/blob_store.go
+++ b/data/sqlite3/blob_store.go
@@ -1,0 +1,42 @@
+package sqlite3
+
+import (
+	"database/sql"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+	sq3 "github.com/mattn/go-sqlite3"
+	"github.com/pkg/errors"
+)
+
+var placeholder = "generating"
+
+type BlobStore struct {
+	TTL      time.Duration
+	LockTime time.Duration
+	DB       *sqlx.DB
+}
+
+func (s *BlobStore) WLock(name string) (bool, error) {
+	_, err := s.DB.Exec("INSERT INTO blobs (name, blob, expires_at) VALUES (?, ?, ?)", name, placeholder, time.Now().Add(s.LockTime))
+	if i, ok := err.(sq3.Error); ok && i.ExtendedCode == sq3.ErrConstraintUnique {
+		return false, nil
+	}
+	return true, err
+}
+
+func (s *BlobStore) Write(name string, blob []byte) error {
+	_, err := s.DB.Exec("REPLACE INTO blobs (name, blob, expires_at) VALUES (?, ?, ?)", name, blob, time.Now().Add(s.LockTime))
+	return err
+}
+
+func (s *BlobStore) Read(name string) ([]byte, error) {
+	var blob []byte
+	err := s.DB.QueryRow("SELECT blob FROM blobs WHERE name = ? AND blob != ? AND expires_at > ?", name, placeholder, time.Now()).Scan(&blob)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	} else if err != nil {
+		return nil, errors.Wrap(err, "Get")
+	}
+	return blob, nil
+}

--- a/data/sqlite3/db.go
+++ b/data/sqlite3/db.go
@@ -9,7 +9,10 @@ import (
 )
 
 func NewDB(env string) (*sqlx.DB, error) {
-	return sqlx.Connect("sqlite3", fmt.Sprintf("./%v.db", env))
+	// https://github.com/mattn/go-sqlite3/issues/274#issuecomment-232942571
+	// enable a busy timeout for concurrent load. keep it short. the busy timeout can be harmful
+	// under sustained load, but helpful during short bursts.
+	return sqlx.Connect("sqlite3", fmt.Sprintf("./%v.db?cache=shared&_busy_timeout=200", env))
 }
 
 func TestDB() (*sqlx.DB, error) {

--- a/data/sqlite3/migrations.go
+++ b/data/sqlite3/migrations.go
@@ -7,7 +7,10 @@ import "github.com/jmoiron/sqlx"
 // determines which steps have run and which steps must still be run. Given the
 // expected final complexity of this project, this is acceptable.
 func MigrateDB(db *sqlx.DB) error {
-	return migration1(db)
+	if err := migration1(db); err != nil {
+		return err
+	}
+	return migration2(db)
 }
 
 func migration1(db *sqlx.DB) error {
@@ -22,6 +25,17 @@ func migration1(db *sqlx.DB) error {
             created_at DATETIME NOT NULL,
             updated_at DATETIME NOT NULL,
             deleted_at DATETIME
+        )
+    `)
+	return err
+}
+
+func migration2(db *sqlx.DB) error {
+	_, err := db.Exec(`
+        CREATE TABLE IF NOT EXISTS refresh_tokens (
+            token TEXT NOT NULL CONSTRAINT uniq UNIQUE,
+            account_id INTEGER NOT NULL,
+            expires_at DATETIME NOT NULL
         )
     `)
 	return err

--- a/data/sqlite3/migrations.go
+++ b/data/sqlite3/migrations.go
@@ -7,10 +7,17 @@ import "github.com/jmoiron/sqlx"
 // determines which steps have run and which steps must still be run. Given the
 // expected final complexity of this project, this is acceptable.
 func MigrateDB(db *sqlx.DB) error {
-	if err := migration1(db); err != nil {
-		return err
+	migrations := []func(db *sqlx.DB) error{
+		migration1,
+		migration2,
+		migration3,
 	}
-	return migration2(db)
+	for _, m := range migrations {
+		if err := m(db); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func migration1(db *sqlx.DB) error {
@@ -35,6 +42,17 @@ func migration2(db *sqlx.DB) error {
         CREATE TABLE IF NOT EXISTS refresh_tokens (
             token TEXT NOT NULL CONSTRAINT uniq UNIQUE,
             account_id INTEGER NOT NULL,
+            expires_at DATETIME NOT NULL
+        )
+    `)
+	return err
+}
+
+func migration3(db *sqlx.DB) error {
+	_, err := db.Exec(`
+        CREATE TABLE IF NOT EXISTS blobs (
+            name TEXT NOT NULL CONSTRAINT uniq UNIQUE,
+            blob BLOB NOT NULL,
             expires_at DATETIME NOT NULL
         )
     `)

--- a/data/sqlite3/refresh_token_store.go
+++ b/data/sqlite3/refresh_token_store.go
@@ -1,0 +1,96 @@
+package sqlite3
+
+import (
+	"database/sql"
+	"encoding/hex"
+	"fmt"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/keratin/authn-server/lib"
+	"github.com/keratin/authn-server/models"
+)
+
+type RefreshTokenStore struct {
+	*sqlx.DB
+	TTL time.Duration
+}
+
+func (s *RefreshTokenStore) Create(accountID int) (models.RefreshToken, error) {
+	binToken, err := lib.GenerateToken()
+	if err != nil {
+		return "", err
+	}
+	token := hex.EncodeToString(binToken)
+
+	_, err = s.Exec(
+		"INSERT INTO refresh_tokens (account_id, token, expires_at) VALUES (?, ?, ?)",
+		accountID,
+		token,
+		time.Now().Add(s.TTL),
+	)
+	if err != nil {
+		return "", err
+	}
+	return models.RefreshToken(token), nil
+}
+
+func (s *RefreshTokenStore) Find(token models.RefreshToken) (int, error) {
+	var accountID int
+	err := s.QueryRow(
+		"SELECT account_id FROM refresh_tokens WHERE token = ? AND expires_at > ?",
+		token,
+		time.Now(),
+	).Scan(&accountID)
+
+	if err == sql.ErrNoRows {
+		return 0, nil
+	} else if err != nil {
+		return 0, err
+	}
+
+	return accountID, nil
+}
+
+func (s *RefreshTokenStore) Touch(token models.RefreshToken, accountID int) error {
+	_, err := s.Exec(
+		"UPDATE refresh_tokens SET expires_at = ? WHERE token = ? AND expires_at > ?",
+		time.Now().Add(s.TTL),
+		token,
+		time.Now(),
+	)
+	return err
+}
+
+func (s *RefreshTokenStore) FindAll(accountID int) ([]models.RefreshToken, error) {
+	var tokens []models.RefreshToken
+	rows, err := s.Query(
+		"SELECT token FROM refresh_tokens WHERE account_id = ? AND expires_at > ?",
+		accountID,
+		time.Now(),
+	)
+	if err != nil {
+		return tokens, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var token models.RefreshToken
+		err := rows.Scan(&token)
+		if err != nil {
+			return []models.RefreshToken{}, err
+		}
+		fmt.Println(token)
+		tokens = append(tokens, token)
+	}
+
+	return tokens, nil
+}
+
+func (s *RefreshTokenStore) Revoke(token models.RefreshToken) error {
+	_, err := s.Exec("DELETE FROM refresh_tokens WHERE token = ?", token)
+	return err
+}
+
+func generateToken() string {
+	return "TODO"
+}

--- a/data/sqlite3/refresh_token_store.go
+++ b/data/sqlite3/refresh_token_store.go
@@ -102,7 +102,3 @@ func (s *RefreshTokenStore) Revoke(token models.RefreshToken) error {
 	_, err := s.Exec("DELETE FROM refresh_tokens WHERE token = ?", token)
 	return err
 }
-
-func generateToken() string {
-	return "TODO"
-}

--- a/data/sqlite3/refresh_token_store.go
+++ b/data/sqlite3/refresh_token_store.go
@@ -86,13 +86,13 @@ func (s *RefreshTokenStore) FindAll(accountID int) ([]models.RefreshToken, error
 	}
 	defer rows.Close()
 	for rows.Next() {
-		var token models.RefreshToken
+		var token string
 		err := rows.Scan(&token)
 		if err != nil {
 			return []models.RefreshToken{}, err
 		}
 		fmt.Println(token)
-		tokens = append(tokens, token)
+		tokens = append(tokens, models.RefreshToken(token))
 	}
 
 	return tokens, nil


### PR DESCRIPTION
The included benchmarks on `GET /session/refresh` show sqlite3 performing comparably to Redis under serialized load. The sqlite3 version may compare even better in a more realistic environment where Redis costs include network latency.

Redis is still a requirement for actives tracking though, and is encoded as a preference when available if for no other reason than familiarity.