### PR TITLE
Redis is optional

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ server: vendor generate
 	docker-compose up -d redis
 	DATABASE_URL=sqlite3://localhost/dev \
 		REDIS_URL=redis://127.0.0.1:8701/11 \
-		go run *.go
+		go run main.go routing.go
 
 # Run tests
 .PHONY: test

--- a/api/meta/get_stats_test.go
+++ b/api/meta/get_stats_test.go
@@ -28,3 +28,16 @@ func TestGetStats(t *testing.T) {
 	assert.Equal(t, []string{"application/json"}, res.Header["Content-Type"])
 	assert.NotEmpty(t, body)
 }
+
+func TestGetStatsWithoutRedis(t *testing.T) {
+	app := test.App()
+	app.Actives = nil
+	server := test.Server(app, meta.Routes(app))
+	defer server.Close()
+
+	client := route.NewClient(server.URL).Authenticated(app.Config.AuthUsername, app.Config.AuthPassword)
+
+	res, err := client.Get("/stats")
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNotFound, res.StatusCode)
+}

--- a/api/meta/routing.go
+++ b/api/meta/routing.go
@@ -9,7 +9,17 @@ import (
 func Routes(app *api.App) []*route.HandledRoute {
 	authentication := route.BasicAuthSecurity(app.Config.AuthUsername, app.Config.AuthPassword, "Private AuthN Realm")
 
-	return []*route.HandledRoute{
+	routes := []*route.HandledRoute{}
+
+	if app.Actives != nil {
+		routes = append(routes,
+			route.Get("/stats").
+				SecuredWith(authentication).
+				Handle(getStats(app)),
+		)
+	}
+
+	routes = append(routes,
 		route.Get("/").
 			SecuredWith(route.Unsecured()).
 			Handle(getRoot(app)),
@@ -22,11 +32,10 @@ func Routes(app *api.App) []*route.HandledRoute {
 		route.Get("/configuration").
 			SecuredWith(route.Unsecured()).
 			Handle(getConfiguration(app)),
-		route.Get("/stats").
-			SecuredWith(authentication).
-			Handle(getStats(app)),
 		route.Get("/metrics").
 			SecuredWith(authentication).
 			Handle(promhttp.Handler()),
-	}
+	)
+
+	return routes
 }

--- a/api/sessions.go
+++ b/api/sessions.go
@@ -54,7 +54,9 @@ func SetSession(cfg *config.Config, w http.ResponseWriter, val string) {
 }
 
 func IdentityForSession(keyStore data.KeyStore, actives data.Actives, cfg *config.Config, session *sessions.Claims, accountID int) (string, error) {
-	actives.Track(accountID)
+	if actives != nil {
+		actives.Track(accountID)
+	}
 	identity := identities.New(cfg, session, accountID)
 	identityToken, err := identity.Sign(keyStore.Key())
 	if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -167,9 +167,6 @@ var configurers = []configurer{
 	func(c *Config) error {
 		val, err := lookupURL("REDIS_URL")
 		if err == nil {
-			if val == nil {
-				return ErrMissingEnvVar("REDIS_URL")
-			}
 			c.RedisURL = val
 		}
 		return err

--- a/data/account_store.go
+++ b/data/account_store.go
@@ -1,6 +1,8 @@
 package data
 
 import (
+	"fmt"
+
 	"github.com/jmoiron/sqlx"
 	"github.com/keratin/authn-server/data/mysql"
 	"github.com/keratin/authn-server/data/sqlite3"
@@ -19,13 +21,13 @@ type AccountStore interface {
 	UpdateUsername(id int, u string) error
 }
 
-func NewAccountStore(db *sqlx.DB) AccountStore {
+func NewAccountStore(db *sqlx.DB) (AccountStore, error) {
 	switch db.DriverName() {
 	case "sqlite3":
-		return &sqlite3.AccountStore{DB: db}
+		return &sqlite3.AccountStore{DB: db}, nil
 	case "mysql":
-		return &mysql.AccountStore{DB: db}
+		return &mysql.AccountStore{DB: db}, nil
 	default:
-		return nil
+		return nil, fmt.Errorf("unsupported driver: %v", db.DriverName())
 	}
 }

--- a/data/refresh_token_store.go
+++ b/data/refresh_token_store.go
@@ -1,6 +1,7 @@
 package data
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/keratin/authn-server/ops"
@@ -35,12 +36,12 @@ type RefreshTokenStore interface {
 	Revoke(t models.RefreshToken) error
 }
 
-func NewRefreshTokenStore(db *sqlx.DB, redis *redis.Client, reporter ops.ErrorReporter, ttl time.Duration) RefreshTokenStore {
+func NewRefreshTokenStore(db *sqlx.DB, redis *redis.Client, reporter ops.ErrorReporter, ttl time.Duration) (RefreshTokenStore, error) {
 	if redis != nil {
 		return &dataRedis.RefreshTokenStore{
 			Client: redis,
 			TTL:    ttl,
-		}
+		}, nil
 	}
 
 	switch db.DriverName() {
@@ -50,8 +51,8 @@ func NewRefreshTokenStore(db *sqlx.DB, redis *redis.Client, reporter ops.ErrorRe
 			TTL: ttl,
 		}
 		store.Clean(reporter)
-		return store
+		return store, nil
 	default:
-		return nil
+		return nil, fmt.Errorf("unsupported driver: %v", db.DriverName())
 	}
 }

--- a/data/sqlite3/blob_store.go
+++ b/data/sqlite3/blob_store.go
@@ -2,6 +2,7 @@ package sqlite3
 
 import (
 	"database/sql"
+	"math/rand"
 	"time"
 
 	"github.com/jmoiron/sqlx"
@@ -20,11 +21,13 @@ type BlobStore struct {
 
 func (s *BlobStore) Clean(reporter ops.ErrorReporter) {
 	go func() {
-		_, err := s.DB.Exec("DELETE FROM blobs WHERE expires_at < ?", time.Now())
-		if err != nil {
-			reporter.ReportError(err)
+		for range time.Tick(time.Minute + time.Duration(rand.Intn(5))*time.Second) {
+			_, err := s.DB.Exec("DELETE FROM blobs WHERE expires_at < ?", time.Now())
+			if err != nil {
+				reporter.ReportError(errors.Wrap(err, "BlobStore Clean"))
+			}
+			time.Sleep(time.Minute)
 		}
-		time.Sleep(time.Minute)
 	}()
 }
 

--- a/docs/guide-deploying_with_docker.md
+++ b/docs/guide-deploying_with_docker.md
@@ -13,27 +13,21 @@ rely on the `:latest` tag, as it is not guaranteed to reflect the newest stable 
 
 ### Daemon
 
-You can run the AuthN Docker image as a daemon. Here's the quickest way to get it running:
+You can run the AuthN Docker image as a daemon. Here's the quickest way to get it running with
+minimal dependencies:
 
 ```sh
-# start a Redis server in the background
-docker run --detach --name authn_redis redis
-
-# then, configure and start an AuthN server on localhost:8080
-docker run \
+docker run -it --rm \
   --publish 8080:3000 \
-  --link authn_redis:rd \
   -e AUTHN_URL=localhost:8080 \
   -e APP_DOMAINS=localhost \
   -e DATABASE_URL=sqlite3:db/demo.sqlite3 \
-  -e REDIS_URL=redis://rd:6379/1 \
   -e SECRET_KEY_BASE=changeme \
   -e HTTP_AUTH_USERNAME=hello \
   -e HTTP_AUTH_PASSWORD=world \
-  --detach \
   --name authn_app \
   keratin/authn-server:latest \
-  sh -c "./authn migrate && ./authn 3000 server"
+  sh -c "./authn migrate && ./authn server"
 ```
 
 ### Compose


### PR DESCRIPTION
It should now be possible to run AuthN from only a SQLite3 database. This makes for an easy dev environment setup, and may be useful for tiny self-contained authentication deployments.

When Redis is configured, AuthN will prefer it for certain use cases like refresh tokens and storing RSA keys. AuthN will also only track active user stats when Redis is available.