### PR TITLE
issue session for requesting origin (enables SSO)

### DIFF
--- a/api/sessions.go
+++ b/api/sessions.go
@@ -23,7 +23,7 @@ func NewSession(refreshTokenStore data.RefreshTokenStore, keyStore data.KeyStore
 		return "", "", errors.Wrap(err, "Sign")
 	}
 
-	identityToken, err := IdentityForSession(keyStore, actives, cfg, session, accountID)
+	identityToken, err := IdentityForSession(keyStore, actives, cfg, session, accountID, authorizedAudience)
 	if err != nil {
 		return "", "", errors.Wrap(err, "IdentityForSession")
 	}
@@ -53,14 +53,13 @@ func SetSession(cfg *config.Config, w http.ResponseWriter, val string) {
 	http.SetCookie(w, cookie)
 }
 
-func IdentityForSession(keyStore data.KeyStore, actives data.Actives, cfg *config.Config, session *sessions.Claims, accountID int) (string, error) {
+func IdentityForSession(keyStore data.KeyStore, actives data.Actives, cfg *config.Config, session *sessions.Claims, accountID int, audience *route.Domain) (string, error) {
 	if actives != nil {
 		actives.Track(accountID)
 	}
-	identity := identities.New(cfg, session, accountID)
-	identityToken, err := identity.Sign(keyStore.Key())
+	identityToken, err := identities.New(cfg, session, accountID, audience.String()).Sign(keyStore.Key())
 	if err != nil {
-		return "", errors.Wrap(err, "Track")
+		return "", errors.Wrap(err, "New")
 	}
 
 	return identityToken, nil

--- a/api/sessions/get_session_refresh.go
+++ b/api/sessions/get_session_refresh.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/keratin/authn-server/api"
+	"github.com/keratin/authn-server/lib/route"
 	"github.com/keratin/authn-server/models"
 )
 
@@ -24,7 +25,7 @@ func getSessionRefresh(app *api.App) http.HandlerFunc {
 		}
 
 		// generate the requested identity token
-		identityToken, err := api.IdentityForSession(app.KeyStore, app.Actives, app.Config, session, accountID)
+		identityToken, err := api.IdentityForSession(app.KeyStore, app.Actives, app.Config, session, accountID, route.MatchedDomain(r))
 		if err != nil {
 			panic(err)
 		}

--- a/tokens/identities/identity.go
+++ b/tokens/identities/identity.go
@@ -39,13 +39,13 @@ func (c *Claims) Sign(rsaKey *rsa.PrivateKey) (string, error) {
 	return jwt.Signed(signer).Claims(c).CompactSerialize()
 }
 
-func New(cfg *config.Config, session *sessions.Claims, accountID int) *Claims {
+func New(cfg *config.Config, session *sessions.Claims, accountID int, audience string) *Claims {
 	return &Claims{
 		AuthTime: session.IssuedAt,
 		Claims: jwt.Claims{
 			Issuer:   session.Issuer,
 			Subject:  strconv.Itoa(accountID),
-			Audience: jwt.Audience{session.Azp},
+			Audience: jwt.Audience{audience},
 			Expiry:   jwt.NewNumericDate(time.Now().Add(cfg.AccessTokenTTL)),
 			IssuedAt: jwt.NewNumericDate(time.Now()),
 		},

--- a/tokens/identities/identity_test.go
+++ b/tokens/identities/identity_test.go
@@ -30,7 +30,7 @@ func TestIdentityClaims(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("includes KID", func(t *testing.T) {
-		identity := identities.New(&cfg, session, 1)
+		identity := identities.New(&cfg, session, 1, "example.com")
 		identityStr, err := identity.Sign(key)
 		require.NoError(t, err)
 


### PR DESCRIPTION
When AuthN is configured for multiple `APP_DOMAINS`, a user may log in with one domain and then transfer their session to another. This works because the user establishes a session with AuthN, and AuthN creates access tokens for authorized domains.