### PR TITLE
fix for archiving more than one account ever

### DIFF
--- a/data/mock/account_store.go
+++ b/data/mock/account_store.go
@@ -68,6 +68,7 @@ func (s *accountStore) Create(u string, p []byte) (*models.Account, error) {
 func (s *accountStore) Archive(id int) error {
 	account := s.accountsByID[id]
 	if account != nil {
+		delete(s.idByUsername, account.Username)
 		now := time.Now()
 		account.Username = ""
 		account.Password = []byte("")

--- a/data/mysql/account_store.go
+++ b/data/mysql/account_store.go
@@ -20,12 +20,15 @@ func (db *AccountStore) Find(id int) (*models.Account, error) {
 	} else if err != nil {
 		return nil, err
 	}
+	if account.DeletedAt != nil {
+		account.Username = ""
+	}
 	return &account, nil
 }
 
 func (db *AccountStore) FindByUsername(u string) (*models.Account, error) {
 	account := models.Account{}
-	err := db.Get(&account, "SELECT * FROM accounts WHERE username = ?", u)
+	err := db.Get(&account, "SELECT * FROM accounts WHERE username = ? AND deleted_at IS NULL", u)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	} else if err != nil {
@@ -63,7 +66,7 @@ func (db *AccountStore) Create(u string, p []byte) (*models.Account, error) {
 }
 
 func (db *AccountStore) Archive(id int) error {
-	_, err := db.Exec("UPDATE accounts SET username = ?, password = ?, deleted_at = ? WHERE id = ?", "", "", time.Now(), id)
+	_, err := db.Exec("UPDATE accounts SET username = CONCAT('@', MD5(RAND())), password = ?, deleted_at = ? WHERE id = ?", "", time.Now(), id)
 	return err
 }
 

--- a/data/mysql/account_store_test.go
+++ b/data/mysql/account_store_test.go
@@ -13,7 +13,7 @@ func TestAccountStore(t *testing.T) {
 	require.NoError(t, err)
 	store := &mysql.AccountStore{db}
 	for _, tester := range testers.AccountStoreTesters {
-		tester(t, store)
 		db.MustExec("TRUNCATE accounts")
+		tester(t, store)
 	}
 }

--- a/data/sqlite3/account_store.go
+++ b/data/sqlite3/account_store.go
@@ -20,12 +20,15 @@ func (db *AccountStore) Find(id int) (*models.Account, error) {
 	} else if err != nil {
 		return nil, err
 	}
+	if account.DeletedAt != nil {
+		account.Username = ""
+	}
 	return &account, nil
 }
 
 func (db *AccountStore) FindByUsername(u string) (*models.Account, error) {
 	account := models.Account{}
-	err := db.Get(&account, "SELECT * FROM accounts WHERE username = ?", u)
+	err := db.Get(&account, "SELECT * FROM accounts WHERE username = ? AND deleted_at IS NULL", u)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	} else if err != nil {
@@ -63,7 +66,7 @@ func (db *AccountStore) Create(u string, p []byte) (*models.Account, error) {
 }
 
 func (db *AccountStore) Archive(id int) error {
-	_, err := db.Exec("UPDATE accounts SET username = ?, password = ?, deleted_at = ? WHERE id = ?", "", "", time.Now(), id)
+	_, err := db.Exec("UPDATE accounts SET username = '@'||HEX(RANDOMBLOB(16)), password = ?, deleted_at = ? WHERE id = ?", "", time.Now(), id)
 	return err
 }
 

--- a/data/sqlite3/refresh_token_store.go
+++ b/data/sqlite3/refresh_token_store.go
@@ -3,7 +3,6 @@ package sqlite3
 import (
 	"database/sql"
 	"encoding/hex"
-	"fmt"
 	"math/rand"
 	"time"
 
@@ -95,7 +94,6 @@ func (s *RefreshTokenStore) FindAll(accountID int) ([]models.RefreshToken, error
 		if err != nil {
 			return []models.RefreshToken{}, err
 		}
-		fmt.Println(token)
 		tokens = append(tokens, models.RefreshToken(token))
 	}
 

--- a/data/testers/account_store_testers.go
+++ b/data/testers/account_store_testers.go
@@ -19,7 +19,7 @@ var AccountStoreTesters = []func(*testing.T, data.AccountStore){
 
 func testCreate(t *testing.T, store data.AccountStore) {
 	account, err := store.Create("authn@keratin.tech", []byte("password"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotEqual(t, 0, account.ID)
 	assert.Equal(t, "authn@keratin.tech", account.Username)
 	assert.NotEmpty(t, account.PasswordChangedAt)

--- a/data/testers/account_store_testers.go
+++ b/data/testers/account_store_testers.go
@@ -83,6 +83,12 @@ func testArchive(t *testing.T, store data.AccountStore) {
 	assert.Empty(t, after.Username)
 	assert.Empty(t, after.Password)
 	assert.NotEmpty(t, after.DeletedAt)
+
+	account2, err := store.Create("authn@keratin.tech", []byte("password"))
+	if assert.NoError(t, err) {
+		err = store.Archive(account2.ID)
+		assert.NoError(t, err)
+	}
 }
 
 func testRequireNewPassword(t *testing.T, store data.AccountStore) {


### PR DESCRIPTION
Previously, the uniqueness constraint on the database would complain when a second account was deleted. This changeset generates random username placeholders when archiving.

There is a very small chance of collision in applications where the username is not validated as an email. This remote possibility seems better than the likely bugs and follow-on effects that could result from adding nil-able usernames into the data model.