### PR TITLE
add logging for invalid origins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## HEAD
 
+### Added
+
+* Log when rejecting a request for a missing or invalid Origin header [#34]
+
 ### Improved
 
 * Query optimizations on private admin endpoints.

--- a/app/app.go
+++ b/app/app.go
@@ -31,7 +31,7 @@ type App struct {
 
 func NewApp(cfg *Config) (*App, error) {
 	logrus.SetFormatter(&logrus.JSONFormatter{})
-	logrus.SetLevel(logrus.InfoLevel)
+	logrus.SetLevel(logrus.DebugLevel)
 	logrus.SetOutput(os.Stdout)
 
 	db, err := data.NewDB(cfg.DatabaseURL)

--- a/lib/route/origin_security.go
+++ b/lib/route/origin_security.go
@@ -3,6 +3,8 @@ package route
 import (
 	"context"
 	"net/http"
+
+	log "github.com/sirupsen/logrus"
 )
 
 type matchedDomainKey int
@@ -14,9 +16,16 @@ type matchedDomainKey int
 // OriginSecurity will store the matching domain in the http.Request's Context. Use MatchedDomain
 // to retrieve the value in later logic.
 func OriginSecurity(domains []Domain) SecurityHandler {
+	var validDomains []string
+	for _, d := range domains {
+		validDomains = append(validDomains, d.String())
+	}
+	logger := log.WithFields(log.Fields{"validDomains": validDomains})
+
 	return func(h http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			domain := FindDomain(r.Header.Get("Origin"), domains)
+			origin := r.Header.Get("Origin")
+			domain := FindDomain(origin, domains)
 			if domain != nil {
 				ctx := r.Context()
 				ctx = context.WithValue(ctx, matchedDomainKey(0), domain)
@@ -25,6 +34,11 @@ func OriginSecurity(domains []Domain) SecurityHandler {
 				return
 			}
 
+			if len(origin) == 0 {
+				logger.Debug("Request origin is missing")
+			} else {
+				logger.WithFields(log.Fields{"origin": origin}).Debug("Request origin is invalid")
+			}
 			w.WriteHeader(http.StatusForbidden)
 			w.Write([]byte("Origin is not a trusted host."))
 		})


### PR DESCRIPTION
Write debug log entries when rejecting a request with an invalid origin. This is intended to help debug CORS failures.

```
~*~ Keratin AuthN server v1.1.0 is ready on http://localhost:7001 (7001) ~*~
{"level":"debug","msg":"Request origin is missing","time":"2017-12-04T20:45:41-08:00","validDomains":["localhost"]}
::1 - - [04/Dec/2017:20:45:41 -0800] "POST /accounts HTTP/1.1" 403 29 "" "HTTPie/0.9.8"
{"level":"debug","msg":"Request origin is invalid","origin":"https://unknown.com","time":"2017-12-04T20:45:43-08:00","validDomains":["localhost"]}
::1 - - [04/Dec/2017:20:45:43 -0800] "POST /accounts HTTP/1.1" 403 29 "" "HTTPie/0.9.8"
```