### PR TITLE
bind a port with only public routes

### DIFF
--- a/api/accounts/routing.go
+++ b/api/accounts/routing.go
@@ -5,9 +5,8 @@ import (
 	"github.com/keratin/authn-server/lib/route"
 )
 
-func Routes(app *api.App) []*route.HandledRoute {
+func PublicRoutes(app *api.App) []*route.HandledRoute {
 	originSecurity := route.OriginSecurity(app.Config.ApplicationDomains)
-	authentication := route.BasicAuthSecurity(app.Config.AuthUsername, app.Config.AuthPassword, "Private AuthN Realm")
 
 	routes := []*route.HandledRoute{}
 
@@ -21,6 +20,14 @@ func Routes(app *api.App) []*route.HandledRoute {
 				Handle(getAccountsAvailable(app)),
 		)
 	}
+
+	return routes
+}
+
+func Routes(app *api.App) []*route.HandledRoute {
+	authentication := route.BasicAuthSecurity(app.Config.AuthUsername, app.Config.AuthPassword, "Private AuthN Realm")
+
+	routes := PublicRoutes(app)
 
 	routes = append(routes,
 		route.Post("/accounts/import").

--- a/api/meta/routing.go
+++ b/api/meta/routing.go
@@ -6,10 +6,18 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
+func PublicRoutes(app *api.App) []*route.HandledRoute {
+	return []*route.HandledRoute{
+		route.Get("/health").
+			SecuredWith(route.Unsecured()).
+			Handle(getHealth(app)),
+	}
+}
+
 func Routes(app *api.App) []*route.HandledRoute {
 	authentication := route.BasicAuthSecurity(app.Config.AuthUsername, app.Config.AuthPassword, "Private AuthN Realm")
 
-	routes := []*route.HandledRoute{}
+	routes := PublicRoutes(app)
 
 	if app.Actives != nil {
 		routes = append(routes,
@@ -23,9 +31,6 @@ func Routes(app *api.App) []*route.HandledRoute {
 		route.Get("/").
 			SecuredWith(route.Unsecured()).
 			Handle(getRoot(app)),
-		route.Get("/health").
-			SecuredWith(route.Unsecured()).
-			Handle(getHealth(app)),
 		route.Get("/jwks").
 			SecuredWith(route.Unsecured()).
 			Handle(getJWKs(app)),

--- a/api/passwords/routing.go
+++ b/api/passwords/routing.go
@@ -5,7 +5,7 @@ import (
 	"github.com/keratin/authn-server/lib/route"
 )
 
-func Routes(app *api.App) []*route.HandledRoute {
+func PublicRoutes(app *api.App) []*route.HandledRoute {
 	originSecurity := route.OriginSecurity(app.Config.ApplicationDomains)
 
 	routes := []*route.HandledRoute{
@@ -23,4 +23,8 @@ func Routes(app *api.App) []*route.HandledRoute {
 	}
 
 	return routes
+}
+
+func Routes(app *api.App) []*route.HandledRoute {
+	return PublicRoutes(app)
 }

--- a/api/sessions/routing.go
+++ b/api/sessions/routing.go
@@ -5,7 +5,7 @@ import (
 	"github.com/keratin/authn-server/lib/route"
 )
 
-func Routes(app *api.App) []*route.HandledRoute {
+func PublicRoutes(app *api.App) []*route.HandledRoute {
 	originSecurity := route.OriginSecurity(app.Config.ApplicationDomains)
 
 	return []*route.HandledRoute{
@@ -21,4 +21,8 @@ func Routes(app *api.App) []*route.HandledRoute {
 			SecuredWith(originSecurity).
 			Handle(getSessionRefresh(app)),
 	}
+}
+
+func Routes(app *api.App) []*route.HandledRoute {
+	return PublicRoutes(app)
 }

--- a/config/config.go
+++ b/config/config.go
@@ -53,6 +53,7 @@ type Config struct {
 	WeeklyActivesRetention int
 	ErrorReporter          ops.ErrorReporter
 	ServerPort             int
+	PublicPort             int
 }
 
 var configurers = []configurer{
@@ -397,6 +398,17 @@ var configurers = []configurer{
 		val, err := lookupInt("PORT", defaultPort)
 		if err == nil {
 			c.ServerPort = val
+		}
+		return err
+	},
+
+	// PUBLIC_PORT is an extra local port the AuthN server listens to with only public routes. This
+	// is useful to avoid exposing admin routes to the public, since you can configure a proxy or
+	// load balancer to forward to only the appropriate port.
+	func(c *Config) error {
+		val, err := lookupInt("PUBLIC_PORT", 0)
+		if err == nil {
+			c.PublicPort = val
 		}
 		return err
 	},

--- a/docs/config.md
+++ b/docs/config.md
@@ -12,7 +12,7 @@ title: Server Configuration
 * Password Policy: [`PASSWORD_POLICY_SCORE`](#password_policy_score) • [`BCRYPT_COST`](#bcrypt_cost)
 * Password Resets: [`APP_PASSWORD_RESET_URL`](#app_password_reset_url) • [`PASSWORD_RESET_TOKEN_TTL`](#password_reset_token_ttl) • [`APP_PASSWORD_CHANGED_URL`](#app_password_changed_url)
 * Stats: [`TIME_ZONE`](#time_zone) • [`DAILY_ACTIVES_RETENTION`](#daily_actives_retention) • [`WEEKLY_ACTIVES_RETENTION`](#weekly_actives_retention)
-* Operations: [`PORT`](#port) • [`SENTRY_DSN`](#sentry_dsn) • [`AIRBRAKE_CREDENTIALS`](#airbrake_credentials)
+* Operations: [`PORT`](#port) • [`PUBLIC_PORT`](#public_port) • [`SENTRY_DSN`](#sentry_dsn) • [`AIRBRAKE_CREDENTIALS`](#airbrake_credentials)
 
 ## Core Settings
 
@@ -291,6 +291,16 @@ Stats on weekly actives will be set to expire after this many weeks. No mechanis
 | Default | from AUTHN_URL |
 
 The PORT specifies where the AuthN server should bind. This may be different from the AUTHN_URL in scenarios with port mapping, as with load balancers and Docker containers.
+
+### `PUBLIC_PORT`
+
+|           |    |
+| --------- | --- |
+| Required? | No |
+| Value | integer |
+| Default | nil |
+
+Specifying PUBLIC_PORT instructs AuthN to bind on a second port with only public routes. This supports network configurations with separate public and private routing. The public load balancer can route to the public port without needing to create and maintain path- & method-based lists of allowed endpoints.
 
 ### `SENTRY_DSN`
 

--- a/docs/guide-deployment.md
+++ b/docs/guide-deployment.md
@@ -29,6 +29,8 @@ AuthN requires:
 
 Ensure that all communication to AuthN happens with SSL.
 
+Configure [`PUBLIC_PORT`](config#public_port) and send all public traffic there.
+
 Give AuthN its own dedicated SQL and Redis databases and be sure that all database backups are
 strongly encrypted at rest. The credentials and accounts data encapsulated by AuthN should not be
 necessary for data warehousing or business intelligence, so try to minimize their exposure.

--- a/main.go
+++ b/main.go
@@ -40,14 +40,17 @@ func serve() {
 		panic(err)
 	}
 
+	fmt.Println(fmt.Sprintf("~*~ Keratin AuthN v%s ~*~", VERSION))
+	fmt.Println(fmt.Sprintf("AUTHN_URL: %s", app.Config.AuthNURL))
+	fmt.Println(fmt.Sprintf("PORT: %d", app.Config.ServerPort))
+
 	if app.Config.PublicPort != 0 {
 		go func() {
-			fmt.Println(fmt.Sprintf("~*~ Keratin AuthN server v%s is listening to public routes on %s (%d) ~*~", VERSION, app.Config.AuthNURL, app.Config.PublicPort))
+			fmt.Println(fmt.Sprintf("PUBLIC_PORT: %d", app.Config.PublicPort))
 			log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", app.Config.PublicPort), publicRouter(app)))
 		}()
 	}
 
-	fmt.Println(fmt.Sprintf("~*~ Keratin AuthN server v%s is listening on %s (%d) ~*~", VERSION, app.Config.AuthNURL, app.Config.ServerPort))
 	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", app.Config.ServerPort), router(app)))
 }
 

--- a/main.go
+++ b/main.go
@@ -40,7 +40,14 @@ func serve() {
 		panic(err)
 	}
 
-	fmt.Println(fmt.Sprintf("~*~ Keratin AuthN server v%s is ready on %s (%d) ~*~", VERSION, app.Config.AuthNURL, app.Config.ServerPort))
+	if app.Config.PublicPort != 0 {
+		go func() {
+			fmt.Println(fmt.Sprintf("~*~ Keratin AuthN server v%s is listening to public routes on %s (%d) ~*~", VERSION, app.Config.AuthNURL, app.Config.PublicPort))
+			log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", app.Config.PublicPort), publicRouter(app)))
+		}()
+	}
+
+	fmt.Println(fmt.Sprintf("~*~ Keratin AuthN server v%s is listening on %s (%d) ~*~", VERSION, app.Config.AuthNURL, app.Config.ServerPort))
 	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", app.Config.ServerPort), router(app)))
 }
 

--- a/routing.go
+++ b/routing.go
@@ -17,12 +17,25 @@ import (
 
 func router(app *api.App) http.Handler {
 	r := mux.NewRouter()
-
 	route.Attach(r, app.Config.MountedPath, meta.Routes(app)...)
 	route.Attach(r, app.Config.MountedPath, accounts.Routes(app)...)
 	route.Attach(r, app.Config.MountedPath, sessions.Routes(app)...)
 	route.Attach(r, app.Config.MountedPath, passwords.Routes(app)...)
 
+	return wrapRouter(r, app)
+}
+
+func publicRouter(app *api.App) http.Handler {
+	r := mux.NewRouter()
+	route.Attach(r, app.Config.MountedPath, meta.PublicRoutes(app)...)
+	route.Attach(r, app.Config.MountedPath, accounts.PublicRoutes(app)...)
+	route.Attach(r, app.Config.MountedPath, sessions.PublicRoutes(app)...)
+	route.Attach(r, app.Config.MountedPath, passwords.PublicRoutes(app)...)
+
+	return wrapRouter(r, app)
+}
+
+func wrapRouter(r *mux.Router, app *api.App) http.Handler {
 	corsAdapter := gorilla.CORS(
 		gorilla.AllowedMethods([]string{"GET", "POST", "PUT", "PATCH", "DELETE"}),
 		gorilla.AllowCredentials(),


### PR DESCRIPTION
By specifying `PUBLIC_PORT`, a person may bind AuthN on two ports with two different routing tables:

1) The standard `PORT`, with all routes (public & private)
2) The optional `PUBLIC_PORT`, with _only_ public routes.

When configured this way, a public load balancer or SSL terminating proxy can easily and safely forward to the public port without concern for exposing admin endpoints to the general internet.

This two-port setup is designed to be backwards compatible. There's a chance it could be revisited and improved in a 2.x release some day.

Fixes #33 