### PR TITLE
use PROXIED flag to enable X-FORWARDED-FOR support

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -54,6 +54,7 @@ type Config struct {
 	ErrorReporter          ops.ErrorReporter
 	ServerPort             int
 	PublicPort             int
+	Proxied                bool
 }
 
 var configurers = []configurer{
@@ -409,6 +410,16 @@ var configurers = []configurer{
 		val, err := lookupInt("PUBLIC_PORT", 0)
 		if err == nil {
 			c.PublicPort = val
+		}
+		return err
+	},
+
+	// PROXIED is a flag that indicates AuthN is behind a proxy. When set, AuthN will read IP
+	// addresses from X-FORWARDED-FOR (and similar).
+	func(c *Config) error {
+		val, err := lookupBool("PROXIED", false)
+		if err == nil {
+			c.Proxied = val
 		}
 		return err
 	},

--- a/docs/config.md
+++ b/docs/config.md
@@ -12,7 +12,7 @@ title: Server Configuration
 * Password Policy: [`PASSWORD_POLICY_SCORE`](#password_policy_score) • [`BCRYPT_COST`](#bcrypt_cost)
 * Password Resets: [`APP_PASSWORD_RESET_URL`](#app_password_reset_url) • [`PASSWORD_RESET_TOKEN_TTL`](#password_reset_token_ttl) • [`APP_PASSWORD_CHANGED_URL`](#app_password_changed_url)
 * Stats: [`TIME_ZONE`](#time_zone) • [`DAILY_ACTIVES_RETENTION`](#daily_actives_retention) • [`WEEKLY_ACTIVES_RETENTION`](#weekly_actives_retention)
-* Operations: [`PORT`](#port) • [`PUBLIC_PORT`](#public_port) • [`SENTRY_DSN`](#sentry_dsn) • [`AIRBRAKE_CREDENTIALS`](#airbrake_credentials)
+* Operations: [`PORT`](#port) • [`PUBLIC_PORT`](#public_port) • [`PROXIED`](#proxied) • [`SENTRY_DSN`](#sentry_dsn) • [`AIRBRAKE_CREDENTIALS`](#airbrake_credentials)
 
 ## Core Settings
 
@@ -301,6 +301,16 @@ The PORT specifies where the AuthN server should bind. This may be different fro
 | Default | nil |
 
 Specifying PUBLIC_PORT instructs AuthN to bind on a second port with only public routes. This supports network configurations with separate public and private routing. The public load balancer can route to the public port without needing to create and maintain path- & method-based lists of allowed endpoints.
+
+### `PROXIED`
+
+|           |    |
+| --------- | --- |
+| Required? | No |
+| Value | boolean (`/^t|true|yes$/i`) |
+| Default | `false` |
+
+Specifying PROXIED allows AuthN to safely read common proxy headers like X-FORWARDED-FOR to determine the true client's IP address. This is currently useful for logging.
 
 ### `SENTRY_DSN`
 

--- a/docs/guide-deployment.md
+++ b/docs/guide-deployment.md
@@ -35,6 +35,12 @@ Give AuthN its own dedicated SQL and Redis databases and be sure that all databa
 strongly encrypted at rest. The credentials and accounts data encapsulated by AuthN should not be
 necessary for data warehousing or business intelligence, so try to minimize their exposure.
 
+## Configuration
+
+* [PORT](config.md#port)
+* [PUBLIC_PORT](config.md#public_port)
+* [PROXIED](config.md#proxied)
+
 ## Related Guides
 
 * [Deploying with Docker](guide-deploying_with_docker.md)


### PR DESCRIPTION
The `PROXIED` env var should be set in deployments where AuthN exists behind a proxy. This is probably true for every production environment, but currently defaults to `false` for backwards compatibility.

The main purpose of `PROXIED` is being able to safely pay attention to `X-FORWARDED-FOR` when determining the client IP address. Without this, logs will always show the proxy as the client.

Fixes #8 