### PR TITLE
streamlined key rotation coordination

### DIFF
--- a/data/blob_store.go
+++ b/data/blob_store.go
@@ -15,15 +15,7 @@ type BlobStore interface {
 	// Read fetches a blob from the store.
 	Read(name string) ([]byte, error)
 
-	// WLock acquires a global mutex that will either timeout or be released by a successful Write
-	WLock(name string) (bool, error)
-
-	// Write puts a blob into the store.
-	Write(name string, blob []byte) error
-
 	// WriteNX will write the blob into the store only if the name does not exist.
-	//
-	// Not compatible with WLock.
 	WriteNX(name string, blob []byte) (bool, error)
 }
 

--- a/data/blob_store.go
+++ b/data/blob_store.go
@@ -15,12 +15,16 @@ type BlobStore interface {
 	// Read fetches a blob from the store.
 	Read(name string) ([]byte, error)
 
-	// WLock acquires a global mutex that will either timeout or be
-	// released by a successful Write
+	// WLock acquires a global mutex that will either timeout or be released by a successful Write
 	WLock(name string) (bool, error)
 
 	// Write puts a blob into the store.
 	Write(name string, blob []byte) error
+
+	// WriteNX will write the blob into the store only if the name does not exist.
+	//
+	// Not compatible with WLock.
+	WriteNX(name string, blob []byte) (bool, error)
 }
 
 func NewBlobStore(interval time.Duration, redis *redis.Client, db *sqlx.DB, reporter ops.ErrorReporter) (BlobStore, error) {

--- a/data/encrypted_blob_store.go
+++ b/data/encrypted_blob_store.go
@@ -23,18 +23,6 @@ func (bs *EncryptedBlobStore) Read(name string) ([]byte, error) {
 	return []byte(val), err
 }
 
-func (bs *EncryptedBlobStore) WLock(name string) (bool, error) {
-	return bs.store.WLock(name)
-}
-
-func (bs *EncryptedBlobStore) Write(name string, blob []byte) error {
-	encryptedBlob, err := compat.Encrypt(blob, bs.encryptionKey)
-	if err != nil {
-		return err
-	}
-	return bs.store.Write(name, encryptedBlob)
-}
-
 func (bs *EncryptedBlobStore) WriteNX(name string, blob []byte) (bool, error) {
 	encryptedBlob, err := compat.Encrypt(blob, bs.encryptionKey)
 	if err != nil {

--- a/data/encrypted_blob_store.go
+++ b/data/encrypted_blob_store.go
@@ -34,3 +34,11 @@ func (bs *EncryptedBlobStore) Write(name string, blob []byte) error {
 	}
 	return bs.store.Write(name, encryptedBlob)
 }
+
+func (bs *EncryptedBlobStore) WriteNX(name string, blob []byte) (bool, error) {
+	encryptedBlob, err := compat.Encrypt(blob, bs.encryptionKey)
+	if err != nil {
+		return false, err
+	}
+	return bs.store.WriteNX(name, encryptedBlob)
+}

--- a/data/encrypted_blob_store_test.go
+++ b/data/encrypted_blob_store_test.go
@@ -14,8 +14,9 @@ func TestEncryptedBlobStore(t *testing.T) {
 	ebs := data.NewEncryptedBlobStore(bs, []byte("secretsecretsecretsecretsecret12"))
 	val := []byte("val")
 
-	err := ebs.Write("key", val)
+	ok, err := ebs.WriteNX("key", val)
 	assert.NoError(t, err)
+	assert.True(t, ok)
 
 	blob, err := bs.Read("key")
 	assert.NoError(t, err)

--- a/data/mock/blob_store.go
+++ b/data/mock/blob_store.go
@@ -21,28 +21,12 @@ func NewBlobStore(ttl time.Duration, lockTime time.Duration) *BlobStore {
 	}
 }
 
-func (bs *BlobStore) Write(name string, blob []byte) error {
-	bs.blobs[name] = blob
-	return nil
-}
-
 func (bs *BlobStore) Read(name string) ([]byte, error) {
 	val := bs.blobs[name]
 	if string(val) == placeholder {
 		return nil, nil
 	}
 	return val, nil
-}
-
-func (bs *BlobStore) WLock(name string) (bool, error) {
-	bs.mutex.Lock()
-	defer bs.mutex.Unlock()
-
-	if bs.blobs[name] == nil {
-		bs.blobs[name] = []byte(placeholder)
-		return true, nil
-	}
-	return false, nil
 }
 
 func (bs *BlobStore) WriteNX(name string, blob []byte) (bool, error) {

--- a/data/mock/blob_store.go
+++ b/data/mock/blob_store.go
@@ -44,3 +44,14 @@ func (bs *BlobStore) WLock(name string) (bool, error) {
 	}
 	return false, nil
 }
+
+func (bs *BlobStore) WriteNX(name string, blob []byte) (bool, error) {
+	bs.mutex.Lock()
+	defer bs.mutex.Unlock()
+
+	if bs.blobs[name] != nil {
+		return false, nil
+	}
+	bs.blobs[name] = blob
+	return true, nil
+}

--- a/data/redis/blob_store.go
+++ b/data/redis/blob_store.go
@@ -34,3 +34,7 @@ func (s *BlobStore) Read(name string) ([]byte, error) {
 	}
 	return []byte(blob), nil
 }
+
+func (s *BlobStore) WriteNX(name string, blob []byte) (bool, error) {
+	return s.Client.SetNX(name, blob, s.TTL).Result()
+}

--- a/data/redis/blob_store.go
+++ b/data/redis/blob_store.go
@@ -15,14 +15,6 @@ type BlobStore struct {
 	Client   *redis.Client
 }
 
-func (s *BlobStore) WLock(name string) (bool, error) {
-	return s.Client.SetNX(name, placeholder, s.LockTime).Result()
-}
-
-func (s *BlobStore) Write(name string, blob []byte) error {
-	return s.Client.Set(name, blob, s.TTL).Err()
-}
-
 func (s *BlobStore) Read(name string) ([]byte, error) {
 	blob, err := s.Client.Get(name).Result()
 	if err == redis.Nil {

--- a/data/sqlite3/blob_store.go
+++ b/data/sqlite3/blob_store.go
@@ -54,3 +54,14 @@ func (s *BlobStore) Read(name string) ([]byte, error) {
 	}
 	return blob, nil
 }
+
+func (s *BlobStore) WriteNX(name string, blob []byte) (bool, error) {
+	_, err := s.DB.Exec("INSERT INTO blobs (name, blob, expires_at) VALUES (?, ?, ?)", name, blob, time.Now().Add(s.TTL))
+	if i, ok := err.(sq3.Error); ok && i.ExtendedCode == sq3.ErrConstraintUnique {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}

--- a/data/sqlite3/blob_store.go
+++ b/data/sqlite3/blob_store.go
@@ -31,19 +31,6 @@ func (s *BlobStore) Clean(reporter ops.ErrorReporter) {
 	}()
 }
 
-func (s *BlobStore) WLock(name string) (bool, error) {
-	_, err := s.DB.Exec("INSERT INTO blobs (name, blob, expires_at) VALUES (?, ?, ?)", name, placeholder, time.Now().Add(s.LockTime))
-	if i, ok := err.(sq3.Error); ok && i.ExtendedCode == sq3.ErrConstraintUnique {
-		return false, nil
-	}
-	return true, err
-}
-
-func (s *BlobStore) Write(name string, blob []byte) error {
-	_, err := s.DB.Exec("REPLACE INTO blobs (name, blob, expires_at) VALUES (?, ?, ?)", name, blob, time.Now().Add(s.TTL))
-	return err
-}
-
 func (s *BlobStore) Read(name string) ([]byte, error) {
 	var blob []byte
 	err := s.DB.QueryRow("SELECT blob FROM blobs WHERE name = ? AND blob != ? AND expires_at > ?", name, placeholder, time.Now()).Scan(&blob)

--- a/data/testers/blob_store_testers.go
+++ b/data/testers/blob_store_testers.go
@@ -5,48 +5,26 @@ import (
 
 	"github.com/keratin/authn-server/data"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var BlobStoreTesters = []func(*testing.T, data.BlobStore){
-	testReadWrite,
-	testWriteLock,
+	testRead,
 	testWriteNX,
 }
 
-func testReadWrite(t *testing.T, bs data.BlobStore) {
+func testRead(t *testing.T, bs data.BlobStore) {
 	blob, err := bs.Read("unknown")
 	assert.NoError(t, err)
 	assert.Empty(t, blob)
 
-	err = bs.Write("blob", []byte("val"))
-	assert.NoError(t, err)
+	ok, err := bs.WriteNX("blob", []byte("val"))
+	require.NoError(t, err)
+	require.True(t, ok)
 
 	blob, err = bs.Read("blob")
 	assert.NoError(t, err)
 	assert.Equal(t, "val", string(blob))
-}
-
-func testWriteLock(t *testing.T, bs data.BlobStore) {
-	ok, err := bs.WLock("lockedKey")
-	assert.NoError(t, err)
-	assert.True(t, ok)
-
-	// can't re-acquire, even with the same connection
-	ok, err = bs.WLock("lockedKey")
-	assert.NoError(t, err)
-	assert.False(t, ok)
-
-	// write lock does not create findable blob
-	blob, err := bs.Read("lockedKey")
-	assert.NoError(t, err)
-	assert.Empty(t, blob)
-
-	// can't lock an existing key
-	err = bs.Write("existing", []byte("val"))
-	assert.NoError(t, err)
-	ok, err = bs.WLock("existing")
-	assert.NoError(t, err)
-	assert.False(t, ok)
 }
 
 func testWriteNX(t *testing.T, bs data.BlobStore) {

--- a/data/testers/blob_store_testers.go
+++ b/data/testers/blob_store_testers.go
@@ -10,6 +10,7 @@ import (
 var BlobStoreTesters = []func(*testing.T, data.BlobStore){
 	testReadWrite,
 	testWriteLock,
+	testWriteNX,
 }
 
 func testReadWrite(t *testing.T, bs data.BlobStore) {
@@ -46,4 +47,14 @@ func testWriteLock(t *testing.T, bs data.BlobStore) {
 	ok, err = bs.WLock("existing")
 	assert.NoError(t, err)
 	assert.False(t, ok)
+}
+
+func testWriteNX(t *testing.T, bs data.BlobStore) {
+	set, err := bs.WriteNX("key", []byte("first"))
+	assert.NoError(t, err)
+	assert.True(t, set)
+
+	set, err = bs.WriteNX("key", []byte("second"))
+	assert.NoError(t, err)
+	assert.False(t, set)
 }


### PR DESCRIPTION
Every AuthN server creates a single routine responsible for periodically rotating the current RSA key. Previously, this routine tried to coordinate with other servers through a Redis mutex. The mutex relied on a lock timeout that could be improperly configured and in the worst case yield competing keys and servers that could not verify each other's tokens.

In a single server environment, the coordination complexity and cost is pointless.

In a multi server environment, the coordination complexity is not worth the saved work. Each server can generate its own key and then compete to see whose key wins.

(Thanks to @shashankmehra for suggesting this enhancement)