### PR TITLE
[Client] Allow use of custom HTTP client in route/client.go

### DIFF
--- a/lib/route/client.go
+++ b/lib/route/client.go
@@ -15,6 +15,7 @@ type modder func(*http.Request) *http.Request
 type Client struct {
 	BaseURL   string
 	Modifiers []modder
+	*http.Client
 }
 
 const (
@@ -28,7 +29,23 @@ const (
 
 // NewClient returns a new Client.
 func NewClient(baseURL string) *Client {
-	return &Client{baseURL, []modder{}}
+	return &Client{
+		BaseURL: baseURL,
+		Client:  http.DefaultClient,
+	}
+}
+
+// With returns a copy of this client with additional modifiers applied after the existing ones
+func (c *Client) With(modifiers ...modder) *Client {
+	// Avoid unintended overwriting of the modifiers if backing array is shared between forked Clients
+	combinedModifiers := make([]modder, len(c.Modifiers)+len(modifiers))
+	n := copy(combinedModifiers, c.Modifiers)
+	copy(combinedModifiers[n:], modifiers)
+	return &Client{
+		BaseURL:   c.BaseURL,
+		Modifiers: combinedModifiers,
+		Client:    c.Client,
+	}
 }
 
 // Referred will inject an Origin header into a client's requests.
@@ -39,35 +56,33 @@ func (c *Client) Referred(domain *Domain) *Client {
 	}
 	origin := fmt.Sprintf("%s://%s", scheme, domain.String())
 
-	return &Client{
-		c.BaseURL,
-		append(c.Modifiers, func(req *http.Request) *http.Request {
-			req.Header.Add("Origin", origin)
-			return req
-		}),
-	}
+	return c.With(func(req *http.Request) *http.Request {
+		req.Header.Add("Origin", origin)
+		return req
+	})
 }
 
 // WithCookie will inject a Cookie header into a client's requests.
 func (c *Client) WithCookie(cookie *http.Cookie) *Client {
-	return &Client{
-		c.BaseURL,
-		append(c.Modifiers, func(req *http.Request) *http.Request {
-			req.AddCookie(cookie)
-			return req
-		}),
-	}
+	return c.With(func(req *http.Request) *http.Request {
+		req.AddCookie(cookie)
+		return req
+	})
+}
+
+// WithClient uses the provided client as the embedded HTTP client
+func (c *Client) WithClient(client *http.Client) *Client {
+	cpy := c.With()
+	c.Client = client
+	return cpy
 }
 
 // Authenticated will inject HTTP Basic Auth configuration into a client's requests.
 func (c *Client) Authenticated(username string, password string) *Client {
-	return &Client{
-		c.BaseURL,
-		append(c.Modifiers, func(req *http.Request) *http.Request {
-			req.SetBasicAuth(username, password)
-			return req
-		}),
-	}
+	return c.With(func(req *http.Request) *http.Request {
+		req.SetBasicAuth(username, password)
+		return req
+	})
 }
 
 // Get issues a GET to the specified path like net/http's Get, but with any modifications
@@ -96,29 +111,26 @@ func (c *Client) Patch(path string, form url.Values) (*http.Response, error) {
 
 // Preflight issues a CORS OPTIONS request
 func (c *Client) Preflight(domain *Domain, verb string, path string) (*http.Response, error) {
-	cPreflight := &Client{
-		c.BaseURL,
-		append(c.Referred(domain).Modifiers, func(req *http.Request) *http.Request {
-			req.Header.Add("Access-Control-Request-Method", verb)
-			return req
-		}),
-	}
+	cPreflight := c.Referred(domain).With(func(req *http.Request) *http.Request {
+		req.Header.Add("Access-Control-Request-Method", verb)
+		return req
+	})
 	return cPreflight.do(options, path, nil)
 }
 
 func (c *Client) do(verb string, path string, body io.Reader) (*http.Response, error) {
 	req, err := http.NewRequest(verb, fmt.Sprintf("%s%s", c.BaseURL, path), body)
+	if err != nil {
+		return nil, err
+	}
 
 	if verb == post || verb == patch || verb == put {
 		req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	}
 
-	if err != nil {
-		return nil, err
-	}
 	for _, mod := range c.Modifiers {
 		req = mod(req)
 	}
 
-	return http.DefaultClient.Do(req)
+	return c.Do(req)
 }


### PR DESCRIPTION
I was writing a Go client wrapper around `Signup` and some other methods, looking at the authn-lib lib/route client I thought I may as well try and reuse that. However I wanted to be able to set up HTTP to user mutual TLS so needed a way to provide the HTTP client. This PR adds the ability to do that.

Incidentally, would it make sense for the go client library (https://github.com/keratin/authn-go) just to be part of authn-server? It seems like there is more comprehensive functionality here than there anyway, along with convenient wrapper types etc.