### PR TITLE
add postresql to newdb switch statement

### DIFF
--- a/app/data/data.go
+++ b/app/data/data.go
@@ -21,7 +21,7 @@ func NewDB(url *url.URL) (*sqlx.DB, error) {
 		return sqlite3.NewDB(url.Path)
 	case "mysql":
 		return mysql.NewDB(url)
-	case "postgres":
+	case "postgresql", "postgres":
 		return postgres.NewDB(url)
 	default:
 		return nil, fmt.Errorf("Unsupported database: %s", url.Scheme)


### PR DESCRIPTION
Added postgresql to the `NewDB` switch statement to match `Migrate`. This fixes breakage trying to connect to CockroachDB