### PR TITLE
Use sqlx.Ext interface rather than *sqlx.DB in all account_store.go

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"github.com/jmoiron/sqlx"
 	"os"
 
 	"github.com/go-redis/redis"
@@ -16,6 +17,7 @@ import (
 type pinger func() bool
 
 type App struct {
+	DB                *sqlx.DB
 	DbCheck           pinger
 	RedisCheck        pinger
 	Config            *Config
@@ -97,6 +99,8 @@ func NewApp(cfg *Config) (*App, error) {
 	}
 
 	return &App{
+		// Provide access to root DB - useful when extending AccountStore functionality
+		DB:                db,
 		DbCheck:           func() bool { return db.Ping() == nil },
 		RedisCheck:        func() bool { return redis != nil && redis.Ping().Err() == nil },
 		Config:            cfg,

--- a/app/data/account_store.go
+++ b/app/data/account_store.go
@@ -27,14 +27,14 @@ type AccountStore interface {
 	SetLastLogin(id int) (bool, error)
 }
 
-func NewAccountStore(db *sqlx.DB) (AccountStore, error) {
+func NewAccountStore(db sqlx.Ext) (AccountStore, error) {
 	switch db.DriverName() {
 	case "sqlite3":
-		return &sqlite3.AccountStore{DB: db}, nil
+		return &sqlite3.AccountStore{Ext: db}, nil
 	case "mysql":
-		return &mysql.AccountStore{DB: db}, nil
+		return &mysql.AccountStore{Ext: db}, nil
 	case "postgres":
-		return &postgres.AccountStore{DB: db}, nil
+		return &postgres.AccountStore{Ext: db}, nil
 	default:
 		return nil, fmt.Errorf("unsupported driver: %v", db.DriverName())
 	}

--- a/app/data/mysql/account_store.go
+++ b/app/data/mysql/account_store.go
@@ -9,12 +9,12 @@ import (
 )
 
 type AccountStore struct {
-	*sqlx.DB
+	sqlx.Ext
 }
 
 func (db *AccountStore) Find(id int) (*models.Account, error) {
 	account := models.Account{}
-	err := db.Get(&account, "SELECT * FROM accounts WHERE id = ?", id)
+	err := sqlx.Get(db, &account, "SELECT * FROM accounts WHERE id = ?", id)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	} else if err != nil {
@@ -28,7 +28,7 @@ func (db *AccountStore) Find(id int) (*models.Account, error) {
 
 func (db *AccountStore) FindByUsername(u string) (*models.Account, error) {
 	account := models.Account{}
-	err := db.Get(&account, "SELECT * FROM accounts WHERE username = ? AND deleted_at IS NULL", u)
+	err := sqlx.Get(db, &account, "SELECT * FROM accounts WHERE username = ? AND deleted_at IS NULL", u)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	} else if err != nil {
@@ -39,7 +39,7 @@ func (db *AccountStore) FindByUsername(u string) (*models.Account, error) {
 
 func (db *AccountStore) FindByOauthAccount(provider string, providerID string) (*models.Account, error) {
 	account := models.Account{}
-	err := db.Get(&account, "SELECT a.* FROM accounts a INNER JOIN oauth_accounts oa ON a.id = oa.account_id WHERE oa.provider = ? AND oa.provider_id = ?", provider, providerID)
+	err := sqlx.Get(db, &account, "SELECT a.* FROM accounts a INNER JOIN oauth_accounts oa ON a.id = oa.account_id WHERE oa.provider = ? AND oa.provider_id = ?", provider, providerID)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	} else if err != nil {
@@ -59,7 +59,7 @@ func (db *AccountStore) Create(u string, p []byte) (*models.Account, error) {
 		UpdatedAt:         now,
 	}
 
-	result, err := db.NamedExec(
+	result, err := sqlx.NamedExec(db,
 		"INSERT INTO accounts (username, password, locked, require_new_password, password_changed_at, created_at, updated_at) VALUES (:username, :password, :locked, :require_new_password, :password_changed_at, :created_at, :updated_at)",
 		account,
 	)
@@ -79,7 +79,7 @@ func (db *AccountStore) Create(u string, p []byte) (*models.Account, error) {
 func (db *AccountStore) AddOauthAccount(accountID int, provider string, providerID string, accessToken string) error {
 	now := time.Now()
 
-	_, err := db.NamedExec(`
+	_, err := sqlx.NamedExec(db, `
         INSERT INTO oauth_accounts (account_id, provider, provider_id, access_token, created_at, updated_at)
         VALUES (:account_id, :provider, :provider_id, :access_token, :created_at, :updated_at)
     `, map[string]interface{}{
@@ -95,7 +95,7 @@ func (db *AccountStore) AddOauthAccount(accountID int, provider string, provider
 
 func (db *AccountStore) GetOauthAccounts(accountID int) ([]*models.OauthAccount, error) {
 	accounts := []*models.OauthAccount{}
-	err := db.Select(&accounts, `SELECT * FROM oauth_accounts WHERE account_id = ?`, accountID)
+	err := sqlx.Select(db, &accounts, `SELECT * FROM oauth_accounts WHERE account_id = ?`, accountID)
 	return accounts, err
 }
 

--- a/app/data/refresh_token_store.go
+++ b/app/data/refresh_token_store.go
@@ -47,7 +47,7 @@ func NewRefreshTokenStore(db *sqlx.DB, redis *redis.Client, reporter ops.ErrorRe
 	switch db.DriverName() {
 	case "sqlite3":
 		store := &sqlite3.RefreshTokenStore{
-			DB:  db,
+			Ext:  db,
 			TTL: ttl,
 		}
 		store.Clean(reporter)

--- a/app/data/sqlite3/account_store.go
+++ b/app/data/sqlite3/account_store.go
@@ -9,12 +9,12 @@ import (
 )
 
 type AccountStore struct {
-	*sqlx.DB
+	sqlx.Ext
 }
 
 func (db *AccountStore) Find(id int) (*models.Account, error) {
 	account := models.Account{}
-	err := db.Get(&account, "SELECT * FROM accounts WHERE id = ?", id)
+	err := sqlx.Get(db, &account, "SELECT * FROM accounts WHERE id = ?", id)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	} else if err != nil {
@@ -28,7 +28,7 @@ func (db *AccountStore) Find(id int) (*models.Account, error) {
 
 func (db *AccountStore) FindByUsername(u string) (*models.Account, error) {
 	account := models.Account{}
-	err := db.Get(&account, "SELECT * FROM accounts WHERE username = ? AND deleted_at IS NULL", u)
+	err := sqlx.Get(db, &account, "SELECT * FROM accounts WHERE username = ? AND deleted_at IS NULL", u)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	} else if err != nil {
@@ -39,7 +39,7 @@ func (db *AccountStore) FindByUsername(u string) (*models.Account, error) {
 
 func (db *AccountStore) FindByOauthAccount(provider string, providerID string) (*models.Account, error) {
 	account := models.Account{}
-	err := db.Get(&account, "SELECT a.* FROM accounts a INNER JOIN oauth_accounts oa ON a.id = oa.account_id WHERE oa.provider = ? AND oa.provider_id = ?", provider, providerID)
+	err := sqlx.Get(db, &account, "SELECT a.* FROM accounts a INNER JOIN oauth_accounts oa ON a.id = oa.account_id WHERE oa.provider = ? AND oa.provider_id = ?", provider, providerID)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	} else if err != nil {
@@ -59,7 +59,7 @@ func (db *AccountStore) Create(u string, p []byte) (*models.Account, error) {
 		UpdatedAt:         now,
 	}
 
-	result, err := db.NamedExec(
+	result, err := sqlx.NamedExec(db,
 		"INSERT INTO accounts (username, password, locked, require_new_password, password_changed_at, created_at, updated_at, last_login_at) VALUES (:username, :password, :locked, :require_new_password, :password_changed_at, :created_at, :updated_at, :last_login_at)",
 		account,
 	)
@@ -79,7 +79,7 @@ func (db *AccountStore) Create(u string, p []byte) (*models.Account, error) {
 func (db *AccountStore) AddOauthAccount(accountID int, provider string, providerID string, accessToken string) error {
 	now := time.Now()
 
-	_, err := db.NamedExec(`
+	_, err := sqlx.NamedExec(db, `
         INSERT INTO oauth_accounts (account_id, provider, provider_id, access_token, created_at, updated_at)
         VALUES (:account_id, :provider, :provider_id, :access_token, :created_at, :updated_at)
     `, map[string]interface{}{
@@ -95,7 +95,7 @@ func (db *AccountStore) AddOauthAccount(accountID int, provider string, provider
 
 func (db *AccountStore) GetOauthAccounts(accountID int) ([]*models.OauthAccount, error) {
 	accounts := []*models.OauthAccount{}
-	err := db.Select(&accounts, `SELECT * FROM oauth_accounts WHERE account_id = ?`, accountID)
+	err := sqlx.Select(db, &accounts, `SELECT * FROM oauth_accounts WHERE account_id = ?`, accountID)
 	return accounts, err
 }
 

--- a/app/data/sqlite3/account_store_test.go
+++ b/app/data/sqlite3/account_store_test.go
@@ -14,6 +14,6 @@ func TestAccountStore(t *testing.T) {
 		require.NoError(t, err)
 		store := &sqlite3.AccountStore{db}
 		tester(t, store)
-		store.Close()
+		db.Close()
 	}
 }

--- a/app/data/sqlite3/blob_store.go
+++ b/app/data/sqlite3/blob_store.go
@@ -16,7 +16,7 @@ var placeholder = "generating"
 type BlobStore struct {
 	TTL      time.Duration
 	LockTime time.Duration
-	DB       *sqlx.DB
+	DB       sqlx.Ext
 }
 
 func (s *BlobStore) Clean(reporter ops.ErrorReporter) {
@@ -33,7 +33,7 @@ func (s *BlobStore) Clean(reporter ops.ErrorReporter) {
 
 func (s *BlobStore) Read(name string) ([]byte, error) {
 	var blob []byte
-	err := s.DB.QueryRow("SELECT blob FROM blobs WHERE name = ? AND blob != ? AND expires_at > ?", name, placeholder, time.Now()).Scan(&blob)
+	err := s.DB.QueryRowx("SELECT blob FROM blobs WHERE name = ? AND blob != ? AND expires_at > ?", name, placeholder, time.Now()).Scan(&blob)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	} else if err != nil {

--- a/app/data/sqlite3/blob_store_test.go
+++ b/app/data/sqlite3/blob_store_test.go
@@ -19,6 +19,6 @@ func TestBlobStore(t *testing.T) {
 			DB:       db,
 		}
 		tester(t, store)
-		store.DB.Close()
+		db.Close()
 	}
 }

--- a/app/data/sqlite3/refresh_token_store.go
+++ b/app/data/sqlite3/refresh_token_store.go
@@ -15,7 +15,7 @@ import (
 )
 
 type RefreshTokenStore struct {
-	*sqlx.DB
+	sqlx.Ext
 	TTL time.Duration
 }
 
@@ -52,7 +52,7 @@ func (s *RefreshTokenStore) Create(accountID int) (models.RefreshToken, error) {
 
 func (s *RefreshTokenStore) Find(token models.RefreshToken) (int, error) {
 	var accountID int
-	err := s.QueryRow(
+	err := s.QueryRowx(
 		"SELECT account_id FROM refresh_tokens WHERE token = ? AND expires_at > ?",
 		token,
 		time.Now(),

--- a/app/data/sqlite3/refresh_token_store_test.go
+++ b/app/data/sqlite3/refresh_token_store_test.go
@@ -15,6 +15,6 @@ func TestRefreshTokenStore(t *testing.T) {
 		require.NoError(t, err)
 		store := &sqlite3.RefreshTokenStore{db, time.Second}
 		tester(t, store)
-		store.Close()
+		db.Close()
 	}
 }


### PR DESCRIPTION
This if the first of my PRs in relation to https://github.com/keratin/authn-server/issues/94. Hopefully it meets your criterion of:

> I'm happy to accept improvements that make AuthN easier to use as a library whenever those improvements are at least net neutral for AuthN as a microservice. 

The interface allows static access to the same methods but allows the
use of a DB or a transaction which faciliates easier extension of
authn-server when used as a library.

For example if you wish to create a user profile or other resources
atomically you may pass a sqlx transaction with sqlx.Beginx

Signed-off-by: Silas Davis <silas@monax.io>