### PR TITLE
Fix zxcvbn divergence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .env
 vendor/
 dist/
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 * panic while evaluating some utf8 password characters
+* zxcvbn library we use exhibited some deviation from standard (see: https://github.com/nbutton23/zxcvbn-go/issues/20) so switched to https://github.com/trustelem/zxcvbn [#99]
 
 ## 1.5.0
 

--- a/app/services/identity_reconciler.go
+++ b/app/services/identity_reconciler.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"encoding/hex"
 	"github.com/keratin/authn-server/app"
 	"github.com/keratin/authn-server/app/data"
 	"github.com/keratin/authn-server/lib"
@@ -56,7 +57,8 @@ func IdentityReconciler(accountStore data.AccountStore, cfg *app.Config, provide
 		return nil, errors.Wrap(err, "GenerateToken")
 	}
 	// TODO: transactional account + identity
-	newAccount, err := AccountCreator(accountStore, cfg, providerUser.Email, string(rand))
+	// Note we hex encode token because zxcvbn does not seem to like non-printable characters
+	newAccount, err := AccountCreator(accountStore, cfg, providerUser.Email, hex.EncodeToString(rand))
 	if err != nil {
 		return nil, errors.Wrap(err, "AccountCreator")
 	}

--- a/app/services/validations.go
+++ b/app/services/validations.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/keratin/authn-server/app"
-	zxcvbn "github.com/nbutton23/zxcvbn-go"
+	"github.com/trustelem/zxcvbn"
 )
 
 var ErrMissing = "MISSING"
@@ -49,7 +49,8 @@ func passwordValidator(cfg *app.Config, password string) *fieldError {
 		password = password[:100]
 	}
 
-	if zxcvbn.PasswordStrength(password, []string{}).Score < cfg.PasswordMinComplexity {
+	strength := zxcvbn.PasswordStrength(password, []string{})
+	if strength.Score < cfg.PasswordMinComplexity {
 		return &fieldError{"password", ErrInsecure}
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -6,12 +6,14 @@ require (
 	github.com/beorn7/perks v0.0.0-20160804104726-4c0e84591b9a // indirect
 	github.com/certifi/gocertifi v0.0.0-20170727155124-3fd9e1adb12b // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/dlclark/regexp2 v1.1.6 // indirect
 	github.com/felixge/httpsnoop v1.0.0
 	github.com/fsnotify/fsnotify v1.4.7 // indirect
 	github.com/getsentry/raven-go v0.0.0-20170614100719-d175f85701df
 	github.com/go-redis/redis v6.10.2+incompatible
 	github.com/go-sql-driver/mysql v1.3.0
 	github.com/golang/protobuf v0.0.0-20171021043952-1643683e1b54 // indirect
+	github.com/google/go-cmp v0.3.0 // indirect
 	github.com/gorilla/context v1.1.1 // indirect
 	github.com/gorilla/handlers v1.3.0
 	github.com/gorilla/mux v1.6.1
@@ -21,7 +23,6 @@ require (
 	github.com/lib/pq v0.0.0-20180327071824-d34b9ff171c2
 	github.com/mattn/go-sqlite3 v1.6.0
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
-	github.com/nbutton23/zxcvbn-go v0.0.0-20180912185939-ae427f1e4c1d
 	github.com/onsi/ginkgo v1.6.0 // indirect
 	github.com/onsi/gomega v1.4.1 // indirect
 	github.com/pkg/errors v0.8.0
@@ -32,6 +33,8 @@ require (
 	github.com/prometheus/procfs v0.0.0-20171017214025-a6e9df898b13 // indirect
 	github.com/sirupsen/logrus v1.0.5
 	github.com/stretchr/testify v1.2.1
+	github.com/test-go/testify v1.1.4 // indirect
+	github.com/trustelem/zxcvbn v1.0.1
 	golang.org/x/crypto v0.0.0-20170619204222-adbae1b6b6fb
 	golang.org/x/net v0.0.0-20170624000434-5f8847ae0d0e // indirect
 	golang.org/x/oauth2 v0.0.0-20180416194528-6881fee410a5

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/certifi/gocertifi v0.0.0-20170727155124-3fd9e1adb12b h1:aKL6D1J3uESUI
 github.com/certifi/gocertifi v0.0.0-20170727155124-3fd9e1adb12b/go.mod h1:GJKEexRPVJrBSOjoqN5VNOIKJ5Q3RViH6eu3puDRwx4=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dlclark/regexp2 v1.1.6 h1:CqB4MjHw0MFCDj+PHHjiESmHX+N7t0tJzKvC6M97BRg=
+github.com/dlclark/regexp2 v1.1.6/go.mod h1:2pZnwuY/m+8K6iRw6wQdMtk+rH5tNGR1i55kozfMjCc=
 github.com/felixge/httpsnoop v1.0.0 h1:gh8fMGz0rlOv/1WmRZm7OgncIOTsAj21iNJot48omJQ=
 github.com/felixge/httpsnoop v1.0.0/go.mod h1:3+D9sFq0ahK/JeJPhCBUV1xlf4/eIYrUQaxulT0VzX8=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
@@ -20,6 +22,8 @@ github.com/go-sql-driver/mysql v1.3.0 h1:pgwjLi/dvffoP9aabwkT3AKpXQM93QARkjFhDDq
 github.com/go-sql-driver/mysql v1.3.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/golang/protobuf v0.0.0-20171021043952-1643683e1b54 h1:nRNJXiJvemchkOTn0V4U11TZkvacB94gTzbTZbSA7Rw=
 github.com/golang/protobuf v0.0.0-20171021043952-1643683e1b54/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
+github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/gorilla/context v1.1.1 h1:AWwleXJkX/nhcU9bZSnZoi3h/qGYqQAGhq6zZe/aQW8=
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
 github.com/gorilla/handlers v1.3.0 h1:tsg9qP3mjt1h4Roxp+M1paRjrVBfPSOpBuVclh6YluI=
@@ -38,8 +42,6 @@ github.com/mattn/go-sqlite3 v1.6.0 h1:TDwTWbeII+88Qy55nWlof0DclgAtI4LqGujkYMzmQI
 github.com/mattn/go-sqlite3 v1.6.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
-github.com/nbutton23/zxcvbn-go v0.0.0-20180912185939-ae427f1e4c1d h1:AREM5mwr4u1ORQBMvzfzBgpsctsbQikCVpvC+tX285E=
-github.com/nbutton23/zxcvbn-go v0.0.0-20180912185939-ae427f1e4c1d/go.mod h1:o96djdrsSGy3AWPyBgZMAGfxZNfgntdJG+11KU4QvbU=
 github.com/onsi/ginkgo v1.6.0 h1:Ix8l273rp3QzYgXSR+c8d1fTG7UPgYkOSELPhiY/YGw=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v1.4.1 h1:PZSj/UFNaVp3KxrzHOcS7oyuWA7LoOY/77yCTEFu21U=
@@ -60,6 +62,10 @@ github.com/sirupsen/logrus v1.0.5 h1:8c8b5uO0zS4X6RPl/sd1ENwSkIc0/H2PaHxE3udaE8I
 github.com/sirupsen/logrus v1.0.5/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=
 github.com/stretchr/testify v1.2.1 h1:52QO5WkIUcHGIR7EnGagH88x1bUzqGXTC5/1bDTUQ7U=
 github.com/stretchr/testify v1.2.1/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/test-go/testify v1.1.4 h1:Tf9lntrKUMHiXQ07qBScBTSA0dhYQlu83hswqelv1iE=
+github.com/test-go/testify v1.1.4/go.mod h1:rH7cfJo/47vWGdi4GPj16x3/t1xGOj2YxzmNQzk2ghU=
+github.com/trustelem/zxcvbn v1.0.1 h1:mp4JFtzdDYGj9WYSD3KQSkwwUumWNFzXaAjckaTYpsc=
+github.com/trustelem/zxcvbn v1.0.1/go.mod h1:zonUyKeh7sw6psPf/e3DtRqkRyZvAbOfjNz/aO7YQ5s=
 golang.org/x/crypto v0.0.0-20170619204222-adbae1b6b6fb h1:6QZjMZJzos5C5rW30xO+0C8f9gKkgeb1z/K4gyS8DFA=
 golang.org/x/crypto v0.0.0-20170619204222-adbae1b6b6fb/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/net v0.0.0-20170624000434-5f8847ae0d0e h1:QgA/R9W9DdyznLiIOAoxKKvtcI4w7iGwJfQp6PoODgk=


### PR DESCRIPTION
While testing my sign up form I noticed that some passwords meeting my strength criteria in JS were failing remotely.

It looks like the zxcvbn library currently used by authn is not conformant: https://github.com/nbutton23/zxcvbn-go/issues/20 

This one looks better, and at the very least passes my single test case: https://github.com/trustelem/zxcvbn and so this PR switches us over to that library.

They seem to have a reasonably good testing regime so hopefully it can be trusted. Pretty sure it is an improvement in any case.