### PR TITLE
Expose public and private routes for extending and overriding

### DIFF
--- a/lib/route/instrument.go
+++ b/lib/route/instrument.go
@@ -32,7 +32,7 @@ func init() {
 	prometheus.MustRegister(httpTimings)
 }
 
-func instrumentRoute(name string, next http.Handler) http.Handler {
+func InstrumentRoute(name string, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		metrics := httpsnoop.CaptureMetrics(next, w, r)
 		httpRequests.WithLabelValues(name, strconv.Itoa(metrics.Code)).Inc()

--- a/lib/route/route.go
+++ b/lib/route/route.go
@@ -16,29 +16,29 @@ type SecurityHandler func(http.Handler) http.Handler
 
 // Post creates a new POST route. A security handler must be registered next.
 func Post(tpl string) *Route {
-	return &Route{verb: "POST", tpl: tpl}
+	return &Route{Verb: "POST", Tpl: tpl}
 }
 
 // Get creates a new GET route. A security handler must be registered next.
 func Get(tpl string) *Route {
-	return &Route{verb: "GET", tpl: tpl}
+	return &Route{Verb: "GET", Tpl: tpl}
 }
 
 // Delete creates a new DELETE route. A security handler must be registered next.
 func Delete(tpl string) *Route {
-	return &Route{verb: "DELETE", tpl: tpl}
+	return &Route{Verb: "DELETE", Tpl: tpl}
 }
 
 // Patch creates a new PATCH route. A security handler must be registered next.
 func Patch(tpl string) *Route {
-	return &Route{verb: "PATCH", tpl: tpl}
+	return &Route{Verb: "PATCH", Tpl: tpl}
 }
 
 // Route is an incomplete Route comprising only verb and path (as a gorilla/mux template). It must
 // next be `SecuredWith`.
 type Route struct {
-	verb string
-	tpl  string
+	Verb string
+	Tpl  string
 }
 
 // SecuredWith registers a security handler for a route. A handler must be registered next.
@@ -64,13 +64,17 @@ type HandledRoute struct {
 	handler http.Handler
 }
 
+func (hr *HandledRoute) ServeHTTP(response http.ResponseWriter, request *http.Request) {
+	hr.security(hr.handler).ServeHTTP(response, request)
+}
+
 // Attach is the adapter for adding HandledRoutes to a gorilla/mux Router.
 func Attach(router *mux.Router, pathPrefix string, routes ...*HandledRoute) {
 	for _, r := range routes {
 		router.
 			PathPrefix(pathPrefix).
-			Methods(r.verb).
-			Path(r.tpl).
-			Handler(instrumentRoute(r.verb+" "+r.tpl, r.security(r.handler)))
+			Methods(r.Verb).
+			Path(r.Tpl).
+			Handler(InstrumentRoute(r.Verb+" "+r.Tpl, r))
 	}
 }

--- a/server/private_routes.go
+++ b/server/private_routes.go
@@ -7,7 +7,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
-func privateRoutes(app *app.App) []*route.HandledRoute {
+func PrivateRoutes(app *app.App) []*route.HandledRoute {
 	var routes []*route.HandledRoute
 	authentication := route.BasicAuthSecurity(app.Config.AuthUsername, app.Config.AuthPassword, "Private AuthN Realm")
 

--- a/server/public_routes.go
+++ b/server/public_routes.go
@@ -6,7 +6,7 @@ import (
 	"github.com/keratin/authn-server/server/handlers"
 )
 
-func publicRoutes(app *app.App) []*route.HandledRoute {
+func PublicRoutes(app *app.App) []*route.HandledRoute {
 	var routes []*route.HandledRoute
 	originSecurity := route.OriginSecurity(app.Config.ApplicationDomains)
 

--- a/server/routers.go
+++ b/server/routers.go
@@ -15,15 +15,15 @@ import (
 
 func Router(app *app.App) http.Handler {
 	r := mux.NewRouter()
-	route.Attach(r, app.Config.MountedPath, privateRoutes(app)...)
-	route.Attach(r, app.Config.MountedPath, publicRoutes(app)...)
+	route.Attach(r, app.Config.MountedPath, PrivateRoutes(app)...)
+	route.Attach(r, app.Config.MountedPath, PublicRoutes(app)...)
 
 	return wrapRouter(r, app)
 }
 
 func PublicRouter(app *app.App) http.Handler {
 	r := mux.NewRouter()
-	route.Attach(r, app.Config.MountedPath, publicRoutes(app)...)
+	route.Attach(r, app.Config.MountedPath, PublicRoutes(app)...)
 
 	return wrapRouter(r, app)
 }


### PR DESCRIPTION
This allows me to take authn-server routes and override and extend whilst being able to use the nice `HandledRoute` structure.

For context in my app I have the following:

`handled_routes.go`:
```go
// Append-only ordered map of routes that ensures no duplicate
type HandledRoutes struct {
	Routes []*route.HandledRoute
	set    map[route.Route]int
}

func Routes() *HandledRoutes {
	return &HandledRoutes{
		set: make(map[route.Route]int),
	}
}

// Adds a route by replacing an existing route mounted at the same location (verb/template) or appending it if it does not
// exist. Replaced routes appear in the same position in the Routes slice so take the same precedent as the route they override
func (hrs *HandledRoutes) add(route *route.HandledRoute) (exists bool) {
	index, exists := hrs.set[route.Route]
	if exists {
		// Override
		hrs.Routes[index] = route
		return true
	}
	hrs.set[route.Route] = len(hrs.Routes)
	hrs.Routes = append(hrs.Routes, route)
	return false
}

// Append some routes to the HandledRoutes collection ensuring they are not duplicates, otherwise panics
func (hrs *HandledRoutes) Append(routes ...*route.HandledRoute) *HandledRoutes {
	for _, r := range routes {
		exists := hrs.add(r)
		if exists {
			panic(fmt.Errorf("attempting to append route at a location already occupied: %v "+
				"- use Override to explicitly override", r.Route))
		}
	}
	return hrs
}

// Override some existing on the HandledRoutes collection ensuring they do already exist, otherwise panics
func (hrs *HandledRoutes) Override(routes ...*route.HandledRoute) *HandledRoutes {
	for _, r := range routes {
		exists := hrs.add(r)
		if !exists {
			panic(fmt.Errorf("attempting to override route at a location that is unoccupied: %v "+
				"- se Append() if you intend to just append a new route", r.Route))
		}
	}
	return hrs
}
```

Which allows me to do:
```go
func AddPublicRoutes(router *mux.Router, app *app.App, id *IDProvider) {
	routes := Routes().Append(server.PublicRoutes(app.Keratin())...).
		Append(idRoutes(id)...).
		Override(publicRoutes(app)...)

	route.Attach(router, app.Config.MountedPath, routes.Routes...)
}

func AddPrivateRoutes(router *mux.Router, app *app.App) {
	routes := Routes().Append(server.PrivateRoutes(app.Keratin())...)

	route.Attach(router, app.Config.MountedPath, routes.Routes...)
}

func publicRoutes(app *app.App) []*route.HandledRoute {
	originSecurity := route.OriginSecurity(app.Config.ApplicationDomains)

	return []*route.HandledRoute{
		route.Post("/accounts").
			SecuredWith(originSecurity).
			Handle(handlers.PostAccount(app)),
	}
}
```

To make sure I don't duplicate routes and am explicit about overriding.