### PR TITLE
Allow same-origin requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## HEAD
 
+### Changed
+* Same-origin requests are now accepted (for browsers that do not send Origin header for same-origin), by falling back to Referer header to determine the application domain that should be selected in the request's context. The Referer header is only consulted when Origin is not set. Since browsers are only permitted to omit Origin header for same-origin requests this behavior should be robust.
+
 ### Added
 
 * Log when rejecting a request for a missing or invalid Origin header [#34]


### PR DESCRIPTION
By infering domain from Referer header iff Origin header is missing.

Some browser (e.g. Firefox) do not send Origin header for same origin requests. Since we implicitly rely on browser to add the header for any cross-origins requests we ought to similarly be able to infer that it is _not_ a cross-origin request when the Origin header is missing. This encodes that assumption and as suggested in #67 uses the Referer header to observe the same origin in question. We fail if the Referer header is missing and we only ever consider the Referer header if the Origin header is missing.

Closes #67.

Signed-off-by: Silas Davis <silas@monax.io>