### PR TITLE
Use an explicit logrus FieldLogger rather than global logger.

### DIFF
--- a/app/services/password_changer_test.go
+++ b/app/services/password_changer_test.go
@@ -8,9 +8,10 @@ import (
 	"github.com/keratin/authn-server/app"
 	"github.com/keratin/authn-server/app/data/mock"
 	"github.com/keratin/authn-server/app/models"
-	"github.com/keratin/authn-server/ops"
 	"github.com/keratin/authn-server/app/services"
+	"github.com/keratin/authn-server/ops"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -23,7 +24,7 @@ func TestPasswordChanger(t *testing.T) {
 	}
 
 	invoke := func(id int, currentPassword string, password string) error {
-		return services.PasswordChanger(accountStore, &ops.LogReporter{}, cfg, id, currentPassword, password)
+		return services.PasswordChanger(accountStore, &ops.LogReporter{logrus.New()}, cfg, id, currentPassword, password)
 	}
 
 	factory := func(username string, password string) (*models.Account, error) {

--- a/app/services/password_reset_sender.go
+++ b/app/services/password_reset_sender.go
@@ -8,10 +8,10 @@ import (
 	"github.com/keratin/authn-server/app/models"
 	"github.com/keratin/authn-server/app/tokens/resets"
 	"github.com/pkg/errors"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
-func PasswordResetSender(cfg *app.Config, account *models.Account) error {
+func PasswordResetSender(cfg *app.Config, account *models.Account, logger logrus.FieldLogger) error {
 	if account == nil || account.Locked {
 		return nil
 	}
@@ -33,7 +33,7 @@ func PasswordResetSender(cfg *app.Config, account *models.Account) error {
 		return errors.Wrap(err, "Webhook")
 	}
 
-	log.WithFields(log.Fields{"accountID": account.ID}).Info("sent password reset token")
+	logger.WithField("accountID", account.ID).Info("sent password reset token")
 
 	return nil
 }

--- a/app/services/password_reset_sender_test.go
+++ b/app/services/password_reset_sender_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/keratin/authn-server/app"
 	"github.com/keratin/authn-server/app/models"
 	"github.com/keratin/authn-server/app/services"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -39,7 +40,7 @@ func TestPasswordResetSender(t *testing.T) {
 			ResetSigningKey:     []byte("resets"),
 			ResetTokenTTL:       time.Minute,
 		}
-		return services.PasswordResetSender(cfg, account)
+		return services.PasswordResetSender(cfg, account, logrus.New())
 	}
 
 	t.Run("posting to remote app", func(t *testing.T) {

--- a/app/services/password_resetter_test.go
+++ b/app/services/password_resetter_test.go
@@ -7,9 +7,10 @@ import (
 
 	"github.com/keratin/authn-server/app"
 	"github.com/keratin/authn-server/app/data/mock"
-	"github.com/keratin/authn-server/ops"
 	"github.com/keratin/authn-server/app/services"
 	"github.com/keratin/authn-server/app/tokens/resets"
+	"github.com/keratin/authn-server/ops"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -32,7 +33,7 @@ func TestPasswordResetter(t *testing.T) {
 	}
 
 	invoke := func(token string, password string) error {
-		_, err := services.PasswordResetter(accountStore, &ops.LogReporter{}, cfg, token, password)
+		_, err := services.PasswordResetter(accountStore, &ops.LogReporter{logrus.New()}, cfg, token, password)
 		return err
 	}
 

--- a/app/services/password_setter_test.go
+++ b/app/services/password_setter_test.go
@@ -5,8 +5,9 @@ import (
 
 	"github.com/keratin/authn-server/app"
 	"github.com/keratin/authn-server/app/data/mock"
-	"github.com/keratin/authn-server/ops"
 	"github.com/keratin/authn-server/app/services"
+	"github.com/keratin/authn-server/ops"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -19,7 +20,7 @@ func TestPasswordSetter(t *testing.T) {
 	}
 
 	invoke := func(id int, password string) error {
-		return services.PasswordSetter(accountStore, &ops.LogReporter{}, cfg, id, password)
+		return services.PasswordSetter(accountStore, &ops.LogReporter{logrus.New()}, cfg, id, password)
 	}
 
 	account, err := accountStore.Create("existing@keratin.tech", []byte("old"))

--- a/app/services/passwordless_token_sender.go
+++ b/app/services/passwordless_token_sender.go
@@ -8,10 +8,10 @@ import (
 	"github.com/keratin/authn-server/app/models"
 	"github.com/keratin/authn-server/app/tokens/passwordless"
 	"github.com/pkg/errors"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
-func PasswordlessTokenSender(cfg *app.Config, account *models.Account) error {
+func PasswordlessTokenSender(cfg *app.Config, account *models.Account, logger logrus.FieldLogger) error {
 	if account == nil || account.Locked {
 		return nil
 	}
@@ -33,7 +33,7 @@ func PasswordlessTokenSender(cfg *app.Config, account *models.Account) error {
 		return errors.Wrap(err, "Webhook")
 	}
 
-	log.WithFields(log.Fields{"accountID": account.ID}).Info("sent passwordless token")
+	logger.WithField("accountID", account.ID).Info("sent passwordless token")
 
 	return nil
 }

--- a/app/services/passwordless_token_sender_test.go
+++ b/app/services/passwordless_token_sender_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/keratin/authn-server/app"
 	"github.com/keratin/authn-server/app/models"
 	"github.com/keratin/authn-server/app/services"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -39,7 +40,7 @@ func TestPasswordlessTokenSender(t *testing.T) {
 			PasswordlessTokenSigningKey: []byte("passwordless"),
 			PasswordlessTokenTTL:        time.Minute,
 		}
-		return services.PasswordlessTokenSender(cfg, account)
+		return services.PasswordlessTokenSender(cfg, account, logrus.New())
 	}
 
 	t.Run("posting to remote app", func(t *testing.T) {

--- a/app/services/passwordless_token_verifier_test.go
+++ b/app/services/passwordless_token_verifier_test.go
@@ -6,9 +6,10 @@ import (
 
 	"github.com/keratin/authn-server/app"
 	"github.com/keratin/authn-server/app/data/mock"
-	"github.com/keratin/authn-server/ops"
 	"github.com/keratin/authn-server/app/services"
 	"github.com/keratin/authn-server/app/tokens/passwordless"
+	"github.com/keratin/authn-server/ops"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -31,7 +32,7 @@ func TestPasswordlessTokenVerifier(t *testing.T) {
 	}
 
 	invoke := func(token string) error {
-		_, err := services.PasswordlessTokenVerifier(accountStore, &ops.LogReporter{}, cfg, token)
+		_, err := services.PasswordlessTokenVerifier(accountStore, &ops.LogReporter{logrus.New()}, cfg, token)
 		return err
 	}
 

--- a/app/services/session_creator_test.go
+++ b/app/services/session_creator_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/keratin/authn-server/app/services"
 	"github.com/keratin/authn-server/lib/route"
 	"github.com/keratin/authn-server/ops"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -23,7 +24,7 @@ func TestSessionCreator(t *testing.T) {
 	keyStore := mock.NewKeyStore(rsaKey)
 	refreshStore := mock.NewRefreshTokenStore()
 	accountStore := mock.NewAccountStore()
-	reporter := &ops.LogReporter{}
+	reporter := &ops.LogReporter{logrus.New()}
 
 	audience := &route.Domain{"authn.example.com", "8080"}
 	account, err := accountStore.Create("existing", []byte("secret"))

--- a/app/services/session_refresher_test.go
+++ b/app/services/session_refresher_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/keratin/authn-server/app/tokens/sessions"
 	"github.com/keratin/authn-server/lib/route"
 	"github.com/keratin/authn-server/ops"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -23,7 +24,7 @@ func TestSessionRefresher(t *testing.T) {
 		AuthNURL: &url.URL{Scheme: "http", Host: "authn.example.com"},
 	}
 	refreshStore := mock.NewRefreshTokenStore()
-	reporter := &ops.LogReporter{}
+	reporter := &ops.LogReporter{logrus.New()}
 
 	accountID := 0
 	audience := &route.Domain{"authn.example.com", "8080"}

--- a/lib/route/origin_security.go
+++ b/lib/route/origin_security.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"net/http"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 type matchedDomainKey int
@@ -15,12 +15,12 @@ type matchedDomainKey int
 //
 // OriginSecurity will store the matching domain in the http.Request's Context. Use MatchedDomain
 // to retrieve the value in later logic.
-func OriginSecurity(domains []Domain) SecurityHandler {
+func OriginSecurity(domains []Domain, logger logrus.FieldLogger) SecurityHandler {
 	var validDomains []string
 	for _, d := range domains {
 		validDomains = append(validDomains, d.String())
 	}
-	logger := log.WithFields(log.Fields{"validDomains": validDomains})
+	logger = logger.WithField("validDomains", validDomains)
 
 	return func(h http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -37,7 +37,7 @@ func OriginSecurity(domains []Domain) SecurityHandler {
 			if len(origin) == 0 {
 				logger.Debug("Could not infer request origin since Origin and Referer headers are both missing")
 			} else {
-				logger.WithFields(log.Fields{"origin": origin}).Debug("Request origin is invalid")
+				logger.WithField("origin", origin).Debug("Request origin is invalid")
 			}
 			w.WriteHeader(http.StatusForbidden)
 			w.Write([]byte("Origin is not a trusted host."))

--- a/lib/route/origin_security_test.go
+++ b/lib/route/origin_security_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/keratin/authn-server/lib/route"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -32,7 +33,7 @@ func TestOriginSecurity(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.domain, func(t *testing.T) {
-			adapter := route.OriginSecurity([]route.Domain{route.ParseDomain(tc.domain)})
+			adapter := route.OriginSecurity([]route.Domain{route.ParseDomain(tc.domain)}, logrus.New())
 
 			server := httptest.NewServer(adapter(nextHandler))
 			defer server.Close()

--- a/ops/log_reporter.go
+++ b/ops/log_reporter.go
@@ -1,20 +1,22 @@
 package ops
 
 import (
-	"log"
 	"net/http"
-	"time"
+
+	"github.com/sirupsen/logrus"
 )
 
 // LogReporter is an ErrorReporter that prints to the log (likely STDOUT)
-type LogReporter struct{}
+type LogReporter struct {
+	logrus.FieldLogger
+}
 
 // ReportError logs error information. The printed details are not robust.
 func (r *LogReporter) ReportError(err error) {
-	log.Printf("[%v] %v\n", time.Now(), err)
+	r.Error(err)
 }
 
 // ReportRequestError logs error information. The printed details are not robust.
 func (r *LogReporter) ReportRequestError(err error, req *http.Request) {
-	log.Printf("[%v][%v %v] %v\n", time.Now(), req.Method, req.URL, err)
+	r.WithFields(logrus.Fields{"method": req.Method, "URL": req.URL}).Error(err)
 }

--- a/server/handlers/get_configuration_test.go
+++ b/server/handlers/get_configuration_test.go
@@ -7,8 +7,9 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/keratin/authn-server/server/test"
 	"github.com/keratin/authn-server/app"
+	"github.com/keratin/authn-server/server/test"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -18,6 +19,7 @@ func TestGetConfiguration(t *testing.T) {
 		Config: &app.Config{
 			AuthNURL: &url.URL{Scheme: "https", Host: "authn.example.com", Path: "/foo"},
 		},
+		Logger: logrus.New(),
 	}
 	server := test.Server(app)
 	defer server.Close()

--- a/server/handlers/get_health_test.go
+++ b/server/handlers/get_health_test.go
@@ -5,8 +5,9 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/keratin/authn-server/server/test"
 	"github.com/keratin/authn-server/app"
+	"github.com/keratin/authn-server/server/test"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -16,6 +17,7 @@ func TestGetHealth(t *testing.T) {
 		DbCheck:    func() bool { return true },
 		RedisCheck: func() bool { return true },
 		Config:     &app.Config{},
+		Logger:     logrus.New(),
 	}
 	server := test.Server(app)
 	defer server.Close()

--- a/server/handlers/get_jwks_test.go
+++ b/server/handlers/get_jwks_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/keratin/authn-server/app/data/private"
+	"github.com/sirupsen/logrus"
 
 	"github.com/keratin/authn-server/app"
 	"github.com/keratin/authn-server/app/data/mock"
@@ -20,6 +21,7 @@ func TestGetJWKs(t *testing.T) {
 	app := &app.App{
 		KeyStore: mock.NewKeyStore(rsaKey),
 		Config:   &app.Config{},
+		Logger:   logrus.New(),
 	}
 
 	server := test.Server(app)

--- a/server/handlers/get_oauth_return.go
+++ b/server/handlers/get_oauth_return.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/keratin/authn-server/server/sessions"
 	"github.com/keratin/authn-server/app"
 	"github.com/keratin/authn-server/app/services"
+	"github.com/keratin/authn-server/server/sessions"
 )
 
 func GetOauthReturn(app *app.App, providerName string) http.HandlerFunc {

--- a/server/handlers/get_password_reset.go
+++ b/server/handlers/get_password_reset.go
@@ -16,7 +16,7 @@ func GetPasswordReset(app *app.App) http.HandlerFunc {
 
 		// run in the background so that a timing attack can't enumerate usernames
 		go func() {
-			err := services.PasswordResetSender(app.Config, account)
+			err := services.PasswordResetSender(app.Config, account, app.Logger)
 			if err != nil {
 				app.Reporter.ReportRequestError(err, r)
 			}

--- a/server/handlers/get_session_refresh_test.go
+++ b/server/handlers/get_session_refresh_test.go
@@ -6,13 +6,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/keratin/authn-server/server/test"
 	"github.com/keratin/authn-server/app"
 	"github.com/keratin/authn-server/app/data/mock"
 	"github.com/keratin/authn-server/app/data/redis"
 	"github.com/keratin/authn-server/app/data/sqlite3"
 	"github.com/keratin/authn-server/lib/route"
 	"github.com/keratin/authn-server/ops"
+	"github.com/keratin/authn-server/server/test"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -110,7 +111,8 @@ func TestGetSessionRefreshFailure(t *testing.T) {
 			ApplicationDomains: []route.Domain{{Hostname: "test.com"}},
 		},
 		RefreshTokenStore: mock.NewRefreshTokenStore(),
-		Reporter:          &ops.LogReporter{},
+		Reporter:          &ops.LogReporter{logrus.New()},
+		Logger:            logrus.New(),
 	}
 	server := test.Server(testApp)
 	defer server.Close()

--- a/server/handlers/get_session_token.go
+++ b/server/handlers/get_session_token.go
@@ -16,7 +16,7 @@ func GetSessionToken(app *app.App) http.HandlerFunc {
 
 		// run in the background so that a timing attack can't enumerate usernames
 		go func() {
-			err := services.PasswordlessTokenSender(app.Config, account)
+			err := services.PasswordlessTokenSender(app.Config, account, app.Logger)
 			if err != nil {
 				app.Reporter.ReportRequestError(err, r)
 			}

--- a/server/public_routes.go
+++ b/server/public_routes.go
@@ -8,7 +8,7 @@ import (
 
 func PublicRoutes(app *app.App) []*route.HandledRoute {
 	var routes []*route.HandledRoute
-	originSecurity := route.OriginSecurity(app.Config.ApplicationDomains)
+	originSecurity := route.OriginSecurity(app.Config.ApplicationDomains, app.Logger)
 
 	routes = append(routes,
 		route.Get("/health").

--- a/server/sessions/middleware_test.go
+++ b/server/sessions/middleware_test.go
@@ -6,12 +6,13 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/keratin/authn-server/server/sessions"
-	"github.com/keratin/authn-server/server/test"
 	"github.com/keratin/authn-server/app"
 	"github.com/keratin/authn-server/app/data/mock"
 	"github.com/keratin/authn-server/lib/route"
 	"github.com/keratin/authn-server/ops"
+	"github.com/keratin/authn-server/server/sessions"
+	"github.com/keratin/authn-server/server/test"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -25,7 +26,7 @@ func TestSession(t *testing.T) {
 			ApplicationDomains: []route.Domain{{Hostname: "example.com"}},
 		},
 		RefreshTokenStore: mock.NewRefreshTokenStore(),
-		Reporter:          &ops.LogReporter{},
+		Reporter:          &ops.LogReporter{logrus.New()},
 	}
 
 	t.Run("valid session", func(t *testing.T) {

--- a/server/test/app.go
+++ b/server/test/app.go
@@ -9,6 +9,7 @@ import (
 	"github.com/keratin/authn-server/lib/oauth"
 	"github.com/keratin/authn-server/lib/route"
 	"github.com/keratin/authn-server/ops"
+	"github.com/sirupsen/logrus"
 )
 
 func App() *app.App {
@@ -35,13 +36,15 @@ func App() *app.App {
 		EnableSignup:            true,
 	}
 
+	logger := logrus.New()
 	return &app.App{
 		Config:            &cfg,
 		KeyStore:          mock.NewKeyStore(weakKey),
 		AccountStore:      mock.NewAccountStore(),
 		RefreshTokenStore: mock.NewRefreshTokenStore(),
 		Actives:           mock.NewActives(),
-		Reporter:          &ops.LogReporter{},
+		Reporter:          &ops.LogReporter{logger},
 		OauthProviders:    map[string]oauth.Provider{},
+		Logger:            logger,
 	}
 }


### PR DESCRIPTION
It is convenient to use a global logger, but it makes it hard to provide coherent logging if you are a dependee using keratin as a library. Moreover it is another source of global state that can cause unwanted effects.

This PR passes loggers as an explicit dependency. I have added to the logger to the `Config` object. At first I wanted to add it to `App` because it doesn't really seem like config. However I added to `Config` in the end because it seems to fit better and:

- `ErrorReporter` doesn't seem like config but is initialised in `Config`. Logger doesn't seem like config either (maybe two wrongs don't make a right)
- If I add it to `App` I would either need to make some functions take `App` that take `Config` (making it even fuzzier what they actually need) or add `logger` as an explicit last argument (I tend to follow this approach in my own code, but it is more susceptible to the complaint that 'loggers get everywhere' - they get where they are used in any case)

I also added a hook that reports logrus errors to our `ErrorReporter`. This is unrelated to the above so I can drop if you like, but I thought it made sense and logrus provides hooks out of the box so I thought why not. If you don't want to keep that I can add a test and make the coverage go up instead of down.