### PR TITLE
Update config.md

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -28,7 +28,7 @@ This specifies the base URL of the AuthN service. It will be embedded in all iss
 |           |    |
 | --------- | --- |
 | Required? | Yes |
-| Value | comma-delimited list of domains (scheme & host, no path) |
+| Value | comma-delimited list of domains (host and optionally port, no path) |
 
 Any domain listed in this variable will be trusted for three things:
 


### PR DESCRIPTION
lib/route/domain.go:16 -`func ParseDomain` splits by colon symbol, so if the schema is provided, it is not parsed correctly.