### PR TITLE
Export fieldError

### DIFF
--- a/app/services/account_creator.go
+++ b/app/services/account_creator.go
@@ -15,12 +15,12 @@ func AccountCreator(store data.AccountStore, cfg *app.Config, username string, p
 
 	errs := FieldErrors{}
 
-	fieldError := usernameValidator(cfg, username)
+	fieldError := UsernameValidator(cfg, username)
 	if fieldError != nil {
 		errs = append(errs, *fieldError)
 	}
 
-	fieldError = passwordValidator(cfg, password)
+	fieldError = PasswordValidator(cfg, password)
 	if fieldError != nil {
 		errs = append(errs, *fieldError)
 	}

--- a/app/services/account_updater.go
+++ b/app/services/account_updater.go
@@ -11,7 +11,7 @@ import (
 func AccountUpdater(store data.AccountStore, cfg *app.Config, accountID int, username string) error {
 	username = strings.TrimSpace(username)
 
-	fieldError := usernameValidator(cfg, username)
+	fieldError := UsernameValidator(cfg, username)
 	if fieldError != nil {
 		return FieldErrors{*fieldError}
 	}

--- a/app/services/password_setter.go
+++ b/app/services/password_setter.go
@@ -12,7 +12,7 @@ import (
 )
 
 func PasswordSetter(store data.AccountStore, r ops.ErrorReporter, cfg *app.Config, accountID int, password string) error {
-	fieldError := passwordValidator(cfg, password)
+	fieldError := PasswordValidator(cfg, password)
 	if fieldError != nil {
 		return FieldErrors{*fieldError}
 	}

--- a/app/services/validations.go
+++ b/app/services/validations.go
@@ -18,16 +18,16 @@ var ErrExpired = "EXPIRED"
 var ErrNotFound = "NOT_FOUND"
 var ErrInvalidOrExpired = "INVALID_OR_EXPIRED"
 
-type fieldError struct {
+type FieldError struct {
 	Field   string `json:"field"`
 	Message string `json:"message"`
 }
 
-func (e fieldError) String() string {
+func (e FieldError) String() string {
 	return fmt.Sprintf("%v: %v", e.Field, e.Message)
 }
 
-type FieldErrors []fieldError
+type FieldErrors []FieldError
 
 func (es FieldErrors) Error() string {
 	var buf = make([]string, len(es))
@@ -37,9 +37,9 @@ func (es FieldErrors) Error() string {
 	return strings.Join(buf, ", ")
 }
 
-func passwordValidator(cfg *app.Config, password string) *fieldError {
+func PasswordValidator(cfg *app.Config, password string) *FieldError {
 	if password == "" {
-		return &fieldError{"password", ErrMissing}
+		return &FieldError{"password", ErrMissing}
 	}
 
 	// SECURITY: only score the first 100 characters of a password. cheap benchmarks on my current
@@ -51,26 +51,26 @@ func passwordValidator(cfg *app.Config, password string) *fieldError {
 
 	strength := zxcvbn.PasswordStrength(password, []string{})
 	if strength.Score < cfg.PasswordMinComplexity {
-		return &fieldError{"password", ErrInsecure}
+		return &FieldError{"password", ErrInsecure}
 	}
 
 	return nil
 }
 
-func usernameValidator(cfg *app.Config, username string) *fieldError {
+func UsernameValidator(cfg *app.Config, username string) *FieldError {
 	if cfg.UsernameIsEmail {
 		if !isEmail(username) {
-			return &fieldError{"username", ErrFormatInvalid}
+			return &FieldError{"username", ErrFormatInvalid}
 		}
 		if len(cfg.UsernameDomains) > 0 && !hasDomain(username, cfg.UsernameDomains) {
-			return &fieldError{"username", ErrFormatInvalid}
+			return &FieldError{"username", ErrFormatInvalid}
 		}
 	} else {
 		if username == "" {
-			return &fieldError{"username", ErrMissing}
+			return &FieldError{"username", ErrMissing}
 		}
 		if len(username) < cfg.UsernameMinLength {
-			return &fieldError{"username", ErrFormatInvalid}
+			return &FieldError{"username", ErrFormatInvalid}
 		}
 	}
 	return nil


### PR DESCRIPTION
Writing unified error handling I would like to use `fieldError`. Currently I can write:

```go
errs := services.FieldErrors{{Field: "Bar, Message: "Foo"}}
```

```go
err := services.FieldError{Field: "Bar, Message: "Foo"}
```

It is also nice to get access to the same username and password validation that core authn uses.