### PR TITLE
Make the zero value of ErrorReporterType 'Log' so as to default to LogReporter

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1,8 +1,6 @@
 package app
 
 import (
-	"os"
-
 	"github.com/go-redis/redis"
 	"github.com/jmoiron/sqlx"
 	"github.com/keratin/authn-server/app/data"
@@ -30,8 +28,8 @@ type App struct {
 	Logger            logrus.FieldLogger
 }
 
-func NewApp(cfg *Config) (*App, error) {
-	errorReporter, err := ops.NewErrorReporter(cfg.ErrorReporterCredentials, cfg.ErrorReporterType)
+func NewApp(cfg *Config, logger logrus.FieldLogger) (*App, error) {
+	errorReporter, err := ops.NewErrorReporter(cfg.ErrorReporterCredentials, cfg.ErrorReporterType, logger)
 
 	db, err := data.NewDB(cfg.DatabaseURL)
 	if err != nil {
@@ -60,12 +58,6 @@ func NewApp(cfg *Config) (*App, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "NewBlobStore")
 	}
-
-	// Default logger
-	logger := logrus.New()
-	logger.Formatter = &logrus.JSONFormatter{}
-	logger.Level = logrus.DebugLevel
-	logger.Out = os.Stdout
 
 	keyStore := data.NewRotatingKeyStore()
 	if cfg.IdentitySigningKey == nil {

--- a/main.go
+++ b/main.go
@@ -5,6 +5,8 @@ import (
 	"github.com/keratin/authn-server/app"
 	"github.com/keratin/authn-server/app/data"
 	"github.com/keratin/authn-server/server"
+	"github.com/sirupsen/logrus"
+
 	"os"
 	"path"
 )
@@ -39,7 +41,13 @@ func main() {
 }
 
 func serve(cfg *app.Config) {
-	app, err := app.NewApp(cfg)
+	// Default logger
+	logger := logrus.New()
+	logger.Formatter = &logrus.JSONFormatter{}
+	logger.Level = logrus.DebugLevel
+	logger.Out = os.Stdout
+
+	app, err := app.NewApp(cfg, logger)
 	if err != nil {
 		fmt.Println(err)
 		return

--- a/ops/error_reporter.go
+++ b/ops/error_reporter.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+
+	"github.com/sirupsen/logrus"
 )
 
 // ErrorReporterType exists to provide context for plain strings in configuration
@@ -11,7 +13,8 @@ type ErrorReporterType int
 
 // all known types of ErrorReporter
 const (
-	Sentry ErrorReporterType = iota
+	Log ErrorReporterType = iota
+	Sentry
 	Airbrake
 )
 
@@ -23,14 +26,16 @@ type ErrorReporter interface {
 }
 
 // NewErrorReporter will instantiate an ErrorReporter for a known type
-func NewErrorReporter(credentials string, t ErrorReporterType) (ErrorReporter, error) {
+func NewErrorReporter(credentials string, t ErrorReporterType, logger logrus.FieldLogger) (ErrorReporter, error) {
 	switch t {
 	case Sentry:
 		return NewSentryReporter(credentials)
 	case Airbrake:
 		return NewAirbrakeReporter(credentials)
 	default:
-		return &LogReporter{}, nil
+		return &LogReporter{
+			FieldLogger: logger.WithField("scope", "NewErrorReporter"),
+		}, nil
 	}
 }
 


### PR DESCRIPTION
Currently if `ErrorReporterType` is unset we get the Zero value which is `Sentry`, even though it is not configured, so nothing happens.

With this PR we default to the log reporter.

I've also realised for the non-global logger to be overridable we need to pass it as an argument to `NewApp` so that we can control the one that gets closed into the various dependencies of App.