### PR TITLE
proper loading of docker secrets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ ORG := keratin
 PROJECT := authn-server
 NAME := $(ORG)/$(PROJECT)
 VERSION := 1.6.0
-MAIN := main.go routing.go
+MAIN := main.go
 
 .PHONY: clean
 clean:
@@ -43,7 +43,7 @@ dist/authn-windows64.exe: init
 # The Docker target wraps the linux/amd64 binary
 .PHONY: dist/docker
 dist/docker: dist/authn-linux64
-	docker build --tag $(NAME):latest .
+	docker build --tag $(NAME):latest --tag $(NAME):$(VERSION) .
 
 # Build all distributables
 .PHONY: dist

--- a/app/env.go
+++ b/app/env.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"io/ioutil"
 	"net/url"
 	"os"
 	"regexp"
@@ -40,6 +41,17 @@ func lookupBool(name string, def bool) (bool, error) {
 func lookupURL(name string) (*url.URL, error) {
 	if val, ok := os.LookupEnv(name); ok {
 		return url.Parse(val)
+	}
+	return nil, nil
+}
+
+func lookupSecureURL(name string) (*url.URL, error) {
+	if fileName, ok := os.LookupEnv(name); ok {
+		val, err := ioutil.ReadFile(fileName)
+		if err != nil {
+			return nil, err
+		}
+		return url.Parse(string(val))
 	}
 	return nil, nil
 }

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+
 	"github.com/keratin/authn-server/app"
 	"github.com/keratin/authn-server/app/data"
 	"github.com/keratin/authn-server/server"
@@ -15,6 +16,8 @@ import (
 var VERSION string
 
 func main() {
+	fmt.Println(fmt.Sprintf("~*~ Keratin AuthN v%s ~*~", VERSION))
+
 	var cmd string
 	if len(os.Args) == 1 {
 		cmd = "server"
@@ -53,7 +56,6 @@ func serve(cfg *app.Config) {
 		return
 	}
 
-	fmt.Println(fmt.Sprintf("~*~ Keratin AuthN v%s ~*~", VERSION))
 	fmt.Println(fmt.Sprintf("AUTHN_URL: %s", cfg.AuthNURL))
 	fmt.Println(fmt.Sprintf("PORT: %d", cfg.ServerPort))
 	if app.Config.PublicPort != 0 {


### PR DESCRIPTION
Main focus is on ability to pass Docker secrets properly instead of environment variables.

If Secure settings are not set, then drop to original mode of loading secrets from environment variables.

Other minor changes:

- App name and version are printed as 1st line on startup to to make sure app is starting
- Added Docker version tags
- removed routing.go from Makefile, because it does not seem to exist (could it be the reason for runtime error I reported?)

Version with these changes is on my Docker space https://cloud.docker.com/repository/docker/kulak/authn-server