### PR TITLE
docs: fix github link (corner widget)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -18,7 +18,7 @@
   <script>
     window.$docsify = {
       name: 'Keratin AuthN',
-      repo: 'https://github.com/keratin/authn-server/docs',
+      repo: 'https://github.com/keratin/authn-server/tree/master/docs',
       coverpage: true,
       loadSidebar: true,
       subMaxLevel: 2,


### PR DESCRIPTION
I guess it should go there; before, it would end up in a 404 page.