### PR TITLE
Add the nocgo build flag to enable a build without sqlite3

### DIFF
--- a/app/data/data.go
+++ b/app/data/data.go
@@ -4,15 +4,13 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/lib/pq"
-
 	my "github.com/go-sql-driver/mysql"
 	"github.com/jmoiron/sqlx"
 	"github.com/keratin/authn-server/app/data/mock"
 	"github.com/keratin/authn-server/app/data/mysql"
 	"github.com/keratin/authn-server/app/data/postgres"
 	"github.com/keratin/authn-server/app/data/sqlite3"
-	sq3 "github.com/mattn/go-sqlite3"
+	"github.com/lib/pq"
 )
 
 func NewDB(url *url.URL) (*sqlx.DB, error) {
@@ -63,8 +61,8 @@ func MigrateDB(url *url.URL) error {
 
 func IsUniquenessError(err error) bool {
 	switch i := err.(type) {
-	case sq3.Error:
-		return i.ExtendedCode == sq3.ErrConstraintUnique
+	case sqlite3.Error:
+		return i.ExtendedCode == sqlite3.ErrConstraintUnique
 	case *my.MySQLError:
 		return i.Number == 1062
 	case *pq.Error:

--- a/app/data/sqlite3/blob_store.go
+++ b/app/data/sqlite3/blob_store.go
@@ -1,3 +1,5 @@
+// +build !nocgo
+
 package sqlite3
 
 import (

--- a/app/data/sqlite3/blob_store_nocgo.go
+++ b/app/data/sqlite3/blob_store_nocgo.go
@@ -1,0 +1,33 @@
+// +build nocgo
+
+// This stub package allows authn-server to be build without CGO, i.e. with CGO_ENABLED=0. This has numerous advantages
+// including on toolchains where static linking is impossible. In order to use it run with `go build -tags nocgo`.
+
+package sqlite3
+
+import (
+	"time"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/keratin/authn-server/ops"
+)
+
+var placeholder = "generating"
+
+type BlobStore struct {
+	TTL      time.Duration
+	LockTime time.Duration
+	DB       sqlx.Ext
+}
+
+func (s *BlobStore) Clean(reporter ops.ErrorReporter) {
+	panic("Cannot use sqlite3 BlobStore because building with nocgo build tag")
+}
+
+func (s *BlobStore) Read(name string) ([]byte, error) {
+	panic("Cannot use sqlite3 BlobStore because building with nocgo build tag")
+}
+
+func (s *BlobStore) WriteNX(name string, blob []byte) (bool, error) {
+	panic("Cannot use sqlite3 BlobStore because building with nocgo build tag")
+}

--- a/app/data/sqlite3/blob_store_test.go
+++ b/app/data/sqlite3/blob_store_test.go
@@ -1,3 +1,5 @@
+// +build !nocgo
+
 package sqlite3_test
 
 import (

--- a/app/data/sqlite3/db.go
+++ b/app/data/sqlite3/db.go
@@ -1,3 +1,5 @@
+// +build !nocgo
+
 package sqlite3
 
 import (
@@ -6,19 +8,23 @@ import (
 
 	"github.com/jmoiron/sqlx"
 	// load sqlite3 library with side effects
-	_ "github.com/mattn/go-sqlite3"
+	sq3 "github.com/mattn/go-sqlite3"
 )
+
+type Error = sq3.Error
+
+var ErrConstraintUnique = sq3.ErrConstraintUnique
 
 func NewDB(env string) (*sqlx.DB, error) {
 	// https://github.com/mattn/go-sqlite3/issues/274#issuecomment-232942571
 	// enable a busy timeout for concurrent load. keep it short. the busy timeout can be harmful
 	// under sustained load, but helpful during short bursts.
-	
-	// this block used to keep backward compatibility 
+
+	// this block used to keep backward compatibility
 	if !strings.Contains(env, ".") {
-		env = "./"+ env +".db"
+		env = "./" + env + ".db"
 	}
-	
+
 	return sqlx.Connect("sqlite3", fmt.Sprintf("%v?cache=shared&_busy_timeout=200", env))
 }
 

--- a/app/data/sqlite3/db_nocgo.go
+++ b/app/data/sqlite3/db_nocgo.go
@@ -1,0 +1,28 @@
+// +build nocgo
+
+// This stub package allows authn-server to be build without CGO, i.e. with CGO_ENABLED=0. This has numerous advantages
+// including on toolchains where static linking is impossible. In order to use it run with `go build -tags nocgo`.
+
+package sqlite3
+
+import (
+	"github.com/jmoiron/sqlx"
+)
+
+type Error struct {
+	ExtendedCode int
+}
+
+func (Error) Error() string {
+	panic("Cannot use sqlite3 Error because building with nocgo build tag")
+}
+
+var ErrConstraintUnique int
+
+func NewDB(env string) (*sqlx.DB, error) {
+	panic("Cannot use sqlite3 DB because building with nocgo build tag")
+}
+
+func TestDB() (*sqlx.DB, error) {
+	panic("Cannot use sqlite3 DB because building with nocgo build tag")
+}


### PR DESCRIPTION
This involves adding some stub files that panic if they are ever used on
a nocgo build - i.e. one excluding sqlite3 but the default build will
build with sqlite3 support using CGO.

CGO is great if you need it, but can cause various types of failures and
complexities particularly on on-standard toolcahins. As a library user I if I do not use sqlite3 I would rather not pay the prices of using CGO.

In particular at the time of writing static CGO builds with go 1.13 do
not work for me on musl-gcc or Arch Linux.

Signed-off-by: Silas Davis <silas@monax.io>