### PR TITLE
Added documentation for ENABLE_SIGNUP

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -1,6 +1,6 @@
 # Server Configuration
 
-* Core Settings: [`AUTHN_URL`](#authn_url) • [`APP_DOMAINS`](#app_domains) • [`HTTP_AUTH_USERNAME`](#http_auth_username) • [`HTTP_AUTH_PASSWORD`](#http_auth_password) • [`SECRET_KEY_BASE`](#secret_key_base)
+* Core Settings: [`AUTHN_URL`](#authn_url) • [`APP_DOMAINS`](#app_domains) • [`HTTP_AUTH_USERNAME`](#http_auth_username) • [`HTTP_AUTH_PASSWORD`](#http_auth_password) • [`SECRET_KEY_BASE`](#secret_key_base) • [`ENABLE_SIGNUP`](#enable_signup)
 * Databases: [`DATABASE_URL`](#database_url) • [`REDIS_URL`](#redis_url)
 * Sessions:
 [`ACCESS_TOKEN_TTL`](#access_token_ttl) • [`REFRESH_TOKEN_TTL`](#refresh_token_ttl) • [`SESSION_KEY_SALT`](#session_key_salt) • [`DB_ENCRYPTION_KEY_SALT`](#db_encryption_key_salt) • [`RSA_PRIVATE_KEY`](#rsa_private_key)
@@ -64,6 +64,17 @@ Any access to private AuthN endpoints must use HTTP Basic Auth, with this passwo
 Any HMAC keys used by AuthN will be derived from this base value. Currently this only includes the key used to securely sign sessions maintained with the AuthN service.
 
 This value is commonly a 64-byte string, and can be generated with [`SecureRandom.hex(64)`](http://ruby-doc.org/stdlib-2.3.3/libdoc/securerandom/rdoc/Random/Formatter.html#method-i-hex) or `bin/rake secret`. Some deployment systems (e.g. Heroku) can provision it automatically.
+
+### `ENABLE_SIGNUP`
+
+|           |    |
+| --------- | --- |
+| Required? | No |
+| Value | boolean (`/^t|true|yes$/i`) |
+| Default | true |
+
+May be set to a falsy value to disable the signup endpoint. If signup is disabled, all users must be created via the private [Import Account endpoint](api.md#import-account).
+
 
 ## Databases
 


### PR DESCRIPTION
Update documentation to include `ENABLE_SIGNUP` so #135 does not happen again :).

I guess a simple write-up may also be a good idea but documenting the environment variable should be enough in the first step