### PR TITLE
support for SameSite property on session cookies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 * Support `Content-Type: application/json` [#143]
+* Support for SameSite property on AuthN session cookie [#147]
 
 ## 1.7.0
 

--- a/app/configure.go
+++ b/app/configure.go
@@ -1,5 +1,7 @@
 package app
 
+import "net/http"
+
 type configurer func(c *Config) error
 
 func configure(fns []configurer) (*Config, error) {
@@ -8,6 +10,7 @@ func configure(fns []configurer) (*Config, error) {
 		UsernameMinLength: 3,
 		SessionCookieName: "authn",
 		OAuthCookieName:   "authn-oauth-nonce",
+		SameSite:          http.SameSiteDefaultMode,
 	}
 	for _, fn := range fns {
 		err = fn(&c)

--- a/server/handlers/util.go
+++ b/server/handlers/util.go
@@ -26,6 +26,7 @@ func nonceCookie(cfg *app.Config, val string) *http.Cookie {
 		Secure:   cfg.ForceSSL,
 		HttpOnly: true,
 		MaxAge:   maxAge,
+		SameSite: cfg.SameSiteComputed(),
 	}
 }
 

--- a/server/sessions/util.go
+++ b/server/sessions/util.go
@@ -31,6 +31,7 @@ func Set(cfg *app.Config, w http.ResponseWriter, val string) {
 		Path:     cfg.MountedPath,
 		Secure:   cfg.ForceSSL,
 		HttpOnly: true,
+		SameSite: cfg.SameSiteComputed(),
 	}
 	if val == "" {
 		cookie.MaxAge = -1

--- a/server/test/app.go
+++ b/server/test/app.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"net/http"
 	"net/url"
 
 	"github.com/keratin/authn-server/app"
@@ -34,6 +35,7 @@ func App() *app.App {
 		AppPasswordResetURL:     &url.URL{Scheme: "https", Host: "app.example.com"},
 		AppPasswordlessTokenURL: &url.URL{Scheme: "https", Host: "app.example.com"},
 		EnableSignup:            true,
+		SameSite:                http.SameSiteDefaultMode,
 	}
 
 	logger := logrus.New()


### PR DESCRIPTION
Closes #146 with a balance of configuration and smart defaults that avoids the maintenance costs of bundling the Public Suffix List.