### PR TITLE
Add SESSION_DOMAIN configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## HEAD
 
 * Added endpoint for checking zxcvbn password score
+* Added `SESSION_DOMAIN` configuration to allow setting session on another domain.
 
 ## 1.8.0
 

--- a/app/config.go
+++ b/app/config.go
@@ -69,6 +69,7 @@ type Config struct {
 	GitHubOauthCredentials      *oauth.Credentials
 	FacebookOauthCredentials    *oauth.Credentials
 	DiscordOauthCredentials     *oauth.Credentials
+	SessionDomain               string
 }
 
 // OAuthEnabled returns true if any provider is configured.
@@ -549,6 +550,18 @@ var configurers = []configurer{
 				c.DiscordOauthCredentials = credentials
 			}
 			return err
+		}
+		return nil
+	},
+
+	// SESSION_DOMAIN defines for which domain (or subdomain) the session cookie will be set.
+	// If not configured, the session would only be found under the domain keratin runs on, for instance authn.example.com.
+	// Setting this value is useful for when you have a SPA with server side rendering that needs to retrieve a session
+	// from a top domain like example.com.
+	func(c *Config) error {
+		val, ok := os.LookupEnv("SESSION_DOMAIN")
+		if ok == true {
+			c.SessionDomain = val
 		}
 		return nil
 	},

--- a/docs/config.md
+++ b/docs/config.md
@@ -3,7 +3,7 @@
 * Core Settings: [`AUTHN_URL`](#authn_url) • [`APP_DOMAINS`](#app_domains) • [`HTTP_AUTH_USERNAME`](#http_auth_username) • [`HTTP_AUTH_PASSWORD`](#http_auth_password) • [`SECRET_KEY_BASE`](#secret_key_base) • [`ENABLE_SIGNUP`](#enable_signup)
 * Databases: [`DATABASE_URL`](#database_url) • [`REDIS_URL`](#redis_url)
 * Sessions:
-[`ACCESS_TOKEN_TTL`](#access_token_ttl) • [`REFRESH_TOKEN_TTL`](#refresh_token_ttl) • [`SESSION_KEY_SALT`](#session_key_salt) • [`DB_ENCRYPTION_KEY_SALT`](#db_encryption_key_salt) • [`RSA_PRIVATE_KEY`](#rsa_private_key) • [`SAME_SITE](#same_site)
+[`ACCESS_TOKEN_TTL`](#access_token_ttl) • [`REFRESH_TOKEN_TTL`](#refresh_token_ttl) • [`SESSION_KEY_SALT`](#session_key_salt) • [`DB_ENCRYPTION_KEY_SALT`](#db_encryption_key_salt) • [`RSA_PRIVATE_KEY`](#rsa_private_key) • [`SAME_SITE`](#same_site) • [`SESSION_DOMAIN`](#session_domain)
 * OAuth Clients: [`FACEBOOK_OAUTH_CREDENTIALS`](#facebook_oauth_credentials) • [`GITHUB_OAUTH_CREDENTIALS`](#github_oauth_credentials) • [`GOOGLE_OAUTH_CREDENTIALS`](#google_oauth_credentials) • [`DISCORD_OAUTH_CREDENTIALS`](#discord_oauth_credentials)
 * Username Policy: [`USERNAME_IS_EMAIL`](#username_is_email) • [`EMAIL_USERNAME_DOMAINS`](#email_username_domains)
 * Password Policy: [`PASSWORD_POLICY_SCORE`](#password_policy_score) • [`BCRYPT_COST`](#bcrypt_cost)
@@ -439,3 +439,20 @@ Configures AuthN to report panics and unhandled errors to a Sentry backend.
 | Default | nil |
 
 Configures AuthN to report panics and unhandled errors to an Airbrake backend. The format is `projectID:projectKey`.
+
+### `SESSION_DOMAIN`
+
+|           |     |
+| --------- | --- |
+| Required? | No |
+| Value | string |
+| Default | nil |
+| Example value | `example.com` |
+
+Configures for which `Domain` the session token will be set.
+When authn is running under `authn.myweb.com` and a web application is deployed to `myweb.com`, both
+domains will have access to this cookie if `SESSION_DOMAIN` is set to `myweb.com`. This is useful if
+`myweb.com` needs access to the refresh token - for example, when having a Server Side Rendered 
+Single Page Application that needs session information. Keep in mind that setting a value will only work
+when Authn is running under the same top domain. Trying to set `example.com` when
+Authn is running under `authn.other.com` will not work, since the browser will block this.

--- a/server/sessions/util.go
+++ b/server/sessions/util.go
@@ -31,6 +31,7 @@ func Set(cfg *app.Config, w http.ResponseWriter, val string) {
 		Path:     cfg.MountedPath,
 		Secure:   cfg.ForceSSL,
 		HttpOnly: true,
+		Domain: cfg.SessionDomain,
 		SameSite: cfg.SameSiteComputed(),
 	}
 	if val == "" {

--- a/server/sessions/util_test.go
+++ b/server/sessions/util_test.go
@@ -1,0 +1,39 @@
+package sessions
+
+import (
+	"github.com/keratin/authn-server/app"
+	"github.com/test-go/testify/assert"
+	"net/http/httptest"
+	"testing"
+)
+
+// ensures that Domain for session cookie is set when app.cfg.SessionDomain exists
+func TestSettingCookieDomain(t *testing.T) {
+	// given
+	cfg := &app.Config{
+		SessionCookieName: "aCookie",
+		SessionDomain:     "example.com",
+	}
+	w := httptest.NewRecorder()
+
+	// when
+	Set(cfg, w, "aCookieValue")
+
+	// then
+	assert.Equal(t, "aCookie=aCookieValue; Domain=example.com; HttpOnly", w.Header().Get("Set-Cookie"))
+}
+
+// ensures that Domain for session cookie is NOT set when app.cfg.SessionDomain is empty
+func TestThatDomainIsNotSetWhenNotPresent(t *testing.T) {
+	// given
+	cfg := &app.Config{
+		SessionCookieName: "aCookie",
+	}
+	w := httptest.NewRecorder()
+
+	// when
+	Set(cfg, w, "aCookieValue")
+
+	// then
+	assert.Equal(t, "aCookie=aCookieValue; HttpOnly", w.Header().Get("Set-Cookie"))
+}


### PR DESCRIPTION
### What
Add the possibility to define `Domain` configuration for the session cookie. 

### Why
Imagine a [SPA](https://en.wikipedia.org/wiki/Single-page_application) running under `example.com` and Authn server running under `authn.example.com`. Up until now, authenticating a user means that a session token will be set exclusively for `authn.example.com`. If this SPA has Server Side Rendering capabilities, there is no way of sending this session token to the server when accessing through `example.com`, since cookie was set for authn domain only. 
This prevents the server from rendering the page as if the user was logged in, since there is no access to said session.

### Restrictions
Setting the Domain will only work if authn is running on the same top domain as the web application, for instance `authn.example.com` and `example.com`