### PR TITLE
option to expire sessions after password update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@ Based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## HEAD
 
-* Added endpoint for checking zxcvbn password score
+### Added
+
+* endpoint for checking zxcvbn password score [#149]
+* option to expire an account's sessions after a password change [#154]
 
 ## 1.8.0
 

--- a/app/config.go
+++ b/app/config.go
@@ -38,6 +38,7 @@ type Config struct {
 	UsernameMinLength           int
 	UsernameDomains             []string
 	PasswordMinComplexity       int
+	PasswordChangeLogout        bool
 	RefreshTokenTTL             time.Duration
 	RedisURL                    *url.URL
 	DatabaseURL                 *url.URL
@@ -185,6 +186,16 @@ var configurers = []configurer{
 		minScore, err := lookupInt("PASSWORD_POLICY_SCORE", 2)
 		if err == nil {
 			c.PasswordMinComplexity = minScore
+		}
+		return err
+	},
+
+	// PASSWORD_CHANGE_LOGOUT will enable a behavior where password resets and updates cause other
+	// devices to be logged out.
+	func(c *Config) error {
+		passwordChangeLogout, err := lookupBool("PASSWORD_CHANGE_LOGOUT", false)
+		if err == nil {
+			c.PasswordChangeLogout = passwordChangeLogout
 		}
 		return err
 	},

--- a/app/configure.go
+++ b/app/configure.go
@@ -7,10 +7,11 @@ type configurer func(c *Config) error
 func configure(fns []configurer) (*Config, error) {
 	var err error
 	c := Config{
-		UsernameMinLength: 3,
-		SessionCookieName: "authn",
-		OAuthCookieName:   "authn-oauth-nonce",
-		SameSite:          http.SameSiteDefaultMode,
+		UsernameMinLength:    3,
+		SessionCookieName:    "authn",
+		OAuthCookieName:      "authn-oauth-nonce",
+		SameSite:             http.SameSiteDefaultMode,
+		PasswordChangeLogout: false,
 	}
 	for _, fn := range fns {
 		err = fn(&c)

--- a/docs/api.md
+++ b/docs/api.md
@@ -68,7 +68,7 @@ Example:
 ```
 
 Errors might also arise when sending unsupported `Content-Type` headers, or improperly formatted JSON/Form content. In this
-case the error message will result in a slightly different payload, accompanied by `400` or `415` Http errors: 
+case the error message will result in a slightly different payload, accompanied by `400` or `415` Http errors:
 
 ```json
 {
@@ -78,9 +78,9 @@ case the error message will result in a slightly different payload, accompanied 
 
 ## Endpoints
 
-All PUT / PATCH / POST endpoints support either JSON (`application/json`) or Form (`application/x-www-form-urlencoded`) 
-encoded requests, depending on which `Content-Type` is found in the request headers. For backwards compatibility, 
-Authn-Server will try parsing a Form request body when no `Content-Type` is set. 
+All PUT / PATCH / POST endpoints support either JSON (`application/json`) or Form (`application/x-www-form-urlencoded`)
+encoded requests, depending on which `Content-Type` is found in the request headers. For backwards compatibility,
+Authn-Server will try parsing a Form request body when no `Content-Type` is set.
 
 ### Signup
 
@@ -493,6 +493,10 @@ Visibility: Public
 
 `POST /password`
 
+Handles password resets (with token) and password changes (with session).
+
+When [`PASSWORD_CHANGE_LOGOUT`](config.md#password_change_logout) is enabled, all existing sessions for the account will be expired before creating a new session on the current device.
+
 | Params | Type | Notes |
 | ------ | ---- | ----- |
 | `password` | string | Must meet minimum complexity scoring per [zxcvbn](https://blogs.dropbox.com/tech/2012/04/zxcvbn-realistic-password-strength-estimation/). |
@@ -564,16 +568,16 @@ Visibility: Public
 | ------ | ---- | ----- |
 | `password` | string | password to be checked for zxcvbn score |
 
-Returns the zxcvbn score and required score set for [`PASSWORD_POLICY_SCORE`](config.md#password_policy_score) for a given password 
+Returns the zxcvbn score and required score set for [`PASSWORD_POLICY_SCORE`](config.md#password_policy_score) for a given password
 
 #### Success:
 
     200 Ok
-    
+
     {
       "result": {
         "score": 3,
-        "requiredScore": 2 
+        "requiredScore": 2
       }
     }
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -6,7 +6,7 @@
 [`ACCESS_TOKEN_TTL`](#access_token_ttl) • [`REFRESH_TOKEN_TTL`](#refresh_token_ttl) • [`SESSION_KEY_SALT`](#session_key_salt) • [`DB_ENCRYPTION_KEY_SALT`](#db_encryption_key_salt) • [`RSA_PRIVATE_KEY`](#rsa_private_key) • [`SAME_SITE](#same_site)
 * OAuth Clients: [`FACEBOOK_OAUTH_CREDENTIALS`](#facebook_oauth_credentials) • [`GITHUB_OAUTH_CREDENTIALS`](#github_oauth_credentials) • [`GOOGLE_OAUTH_CREDENTIALS`](#google_oauth_credentials) • [`DISCORD_OAUTH_CREDENTIALS`](#discord_oauth_credentials)
 * Username Policy: [`USERNAME_IS_EMAIL`](#username_is_email) • [`EMAIL_USERNAME_DOMAINS`](#email_username_domains)
-* Password Policy: [`PASSWORD_POLICY_SCORE`](#password_policy_score) • [`BCRYPT_COST`](#bcrypt_cost)
+* Password Policy: [`PASSWORD_POLICY_SCORE`](#password_policy_score) • [`PASSWORD_CHANGE_LOGOUT`](#password_change_logout) • [`BCRYPT_COST`](#bcrypt_cost)
 * Password Resets: [`APP_PASSWORD_RESET_URL`](#app_password_reset_url) • [`PASSWORD_RESET_TOKEN_TTL`](#password_reset_token_ttl) • [`APP_PASSWORD_CHANGED_URL`](#app_password_changed_url)
 * Passwordless: [`APP_PASSWORDLESS_TOKEN_URL`](#app_passwordless_token_url) • [`PASSWORDLESS_TOKEN_TTL`](#passwordless_token_ttl)
 * Stats: [`TIME_ZONE`](#time_zone) • [`DAILY_ACTIVES_RETENTION`](#daily_actives_retention) • [`WEEKLY_ACTIVES_RETENTION`](#weekly_actives_retention)
@@ -281,6 +281,16 @@ If you need to restrict account creation to specific email domains, declare the 
 * 4 - very unguessable
 
 Password complexity is calculated by estimating how many guesses it would take a smart attacker armed with a dictionary, simple transformations like L337, and spatial walks across the QWERTY keyboard. The specific algorithm used is [zxcvbn](https://blogs.dropbox.com/tech/2012/04/zxcvbn-realistic-password-strength-estimation/), which has a JavaScript implementation if you'd like to provide real-time user feedback on password fields.
+
+### `PASSWORD_CHANGE_LOGOUT`
+
+|           |    |
+| --------- | --- |
+| Required? | No |
+| Value | boolean (`/^t|true|yes$/i`) |
+| Default | false |
+
+Enable if you would like user password changes to expire all other sessions for the account.
 
 ### `BCRYPT_COST`
 

--- a/server/handlers/post_password.go
+++ b/server/handlers/post_password.go
@@ -1,20 +1,21 @@
 package handlers
 
 import (
-	"github.com/keratin/authn-server/lib/parse"
 	"net/http"
 
-	"github.com/keratin/authn-server/server/sessions"
+	"github.com/keratin/authn-server/lib/parse"
+
 	"github.com/keratin/authn-server/app"
-	"github.com/keratin/authn-server/lib/route"
 	"github.com/keratin/authn-server/app/services"
+	"github.com/keratin/authn-server/lib/route"
+	"github.com/keratin/authn-server/server/sessions"
 )
 
 func PostPassword(app *app.App) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		var credentials struct {
-			Token string
-			Password string
+			Token           string
+			Password        string
 			CurrentPassword string
 		}
 		if err := parse.Payload(r, &credentials); err != nil {
@@ -55,6 +56,13 @@ func PostPassword(app *app.App) http.HandlerFunc {
 			}
 
 			panic(err)
+		}
+
+		if app.Config.PasswordChangeLogout {
+			err = services.SessionBatchEnder(app.RefreshTokenStore, accountID)
+			if err != nil {
+				panic(err)
+			}
 		}
 
 		sessionToken, identityToken, err := services.SessionCreator(

--- a/server/test/app.go
+++ b/server/test/app.go
@@ -36,6 +36,7 @@ func App() *app.App {
 		AppPasswordlessTokenURL: &url.URL{Scheme: "https", Host: "app.example.com"},
 		EnableSignup:            true,
 		SameSite:                http.SameSiteDefaultMode,
+		PasswordChangeLogout:    false,
 	}
 
 	logger := logrus.New()


### PR DESCRIPTION
This change adds a server setting called `PASSWORD_CHANGE_LOGOUT` to expire an account's sessions across all devices when the user changes their password, as per the OWASP recommendations. This setting may become the default behavior in a 2.0 version.

fixes #153