### PR TITLE
Release with GitHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,11 +28,14 @@ jobs:
           GOARCH: amd64
           CGO_ENABLED: 1
 
-      # TODO: add to release
+      - name: compress
+        run: |
+          bzip2 -c dist/authn-linux64 > dist/authn-linux64.bz2
+
       - uses: actions/upload-artifact@v2
         with:
-          name: authn-linux64
-          path: dist/authn-linux64
+          name: authn-linux64.bz2
+          path: dist/authn-linux64.bz2
 
   windows64:
     name: Compile for Windows
@@ -50,7 +53,7 @@ jobs:
         run: |
           go build \
             -ldflags '-X main.VERSION=${VERSION:1}' \
-            -o dist/authn-windows64
+            -o dist/authn-windows64.exe
         env:
           VERSION: ${{ github.ref }}
           GOOS: windows
@@ -58,11 +61,10 @@ jobs:
           CGO_ENABLED: 1
           CC: x86_64-w64-mingw32-gcc
 
-      # TODO: add to release
       - uses: actions/upload-artifact@v2
         with:
-          name: authn-windows64
-          path: dist/authn-windows64
+          name: authn-windows64.exe
+          path: dist/authn-windows64.exe
 
   macos64:
     name: Compile for MacOS
@@ -86,8 +88,61 @@ jobs:
           GOARCH: amd64
           CGO_ENABLED: 1
 
-      # TODO: add to release
+      - name: compress
+        run: |
+          bzip2 -c dist/authn-macos64 > dist/authn-macos64.bz2
+
       - uses: actions/upload-artifact@v2
         with:
-          name: authn-macos64
-          path: dist/authn-macos64
+          name: authn-macos64.bz2
+          path: dist/authn-macos64.bz2
+
+  release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    needs: [linux64, windows64, macos64]
+
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v2
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          draft: true
+          prerelease: true # TODO: toggle before merge
+
+      - name: Upload Linux64
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./authn-linux64.bz2/authn-linux64.bz2
+          asset_name: authn-linux64.bz2
+          asset_content_type: application/x-bzip2
+
+      - name: Upload Windows64
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./authn-windows64.exe/authn-windows64.exe
+          asset_name: authn-windows64.exe
+          asset_content_type: application/vnd.microsoft.portable-executable
+
+      - name: Upload Macos64
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./authn-macos64.bz2/authn-macos64.bz2
+          asset_name: authn-macos64.bz2
+          asset_content_type: application/x-bzip2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on: push
 
 jobs:
   linux64:
-    name: Compile for Linux64
+    name: Compile for Linux
     runs-on: ubuntu-latest
 
     steps:
@@ -18,15 +18,13 @@ jobs:
           go-version: ^1.15
       - run: go mod download
 
-      - name: release version
-        run: echo ${GITHUB_REF}
-
       - name: compile
         run: |
           go build \
-            -ldflags '-extldflags -static -X main.VERSION=${GITHUB_REF}' \
+            -ldflags '-extldflags -static -X main.VERSION=${VERSION}' \
             -o dist/authn-linux64
         env:
+          VERSION: ${{ github.ref }}
           GOOS: linux
           GOARCH: amd64
           CGO_ENABLED: 1
@@ -38,7 +36,7 @@ jobs:
           path: dist/authn-linux64
 
   windows64:
-    name: Compile for Windows64
+    name: Compile for Windows
     runs-on: ubuntu-latest
 
     steps:
@@ -52,9 +50,10 @@ jobs:
       - name: compile
         run: |
           go build \
-            -ldflags '-X main.VERSION=$(VERSION)' \
+            -ldflags '-X main.VERSION=${VERSION}' \
             -o dist/authn-windows64
         env:
+          VERSION: ${{ github.ref }}
           GOOS: windows
           GOARCH: amd64
           CGO_ENABLED: 1
@@ -65,3 +64,31 @@ jobs:
         with:
           name: authn-windows64
           path: dist/authn-windows64
+
+  macos64:
+    name: Compile for MacOS
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ^1.15
+      - run: go mod download
+
+      - name: compile
+        run: |
+          go build \
+            -ldflags "-X main.VERSION=${VERSION}" \
+            -o dist/authn-macos64
+        env:
+          VERSION: ${{ github.ref }}
+          GOOS: darwin
+          GOARCH: amd64
+          CGO_ENABLED: 1
+
+      # TODO: add to release
+      - uses: actions/upload-artifact@v2
+        with:
+          name: authn-macos64
+          path: dist/authn-macos64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: compile
         run: |
           go build \
-            -ldflags '-extldflags -static -X main.VERSION=${VERSION:1}' \
+            -ldflags '-extldflags -static -X main.VERSION=${VERSION##*/v}' \
             -o dist/authn-linux64
         env:
           VERSION: ${{ github.ref }}
@@ -52,7 +52,7 @@ jobs:
       - name: compile
         run: |
           go build \
-            -ldflags '-X main.VERSION=${VERSION:1}' \
+            -ldflags '-X main.VERSION=${VERSION##*/v}' \
             -o dist/authn-windows64.exe
         env:
           VERSION: ${{ github.ref }}
@@ -80,7 +80,7 @@ jobs:
       - name: compile
         run: |
           go build \
-            -ldflags "-X main.VERSION=${VERSION:1}" \
+            -ldflags "-X main.VERSION=${VERSION##*/v}" \
             -o dist/authn-macos64
         env:
           VERSION: ${{ github.ref }}
@@ -173,7 +173,7 @@ jobs:
       - name: VERSION
         id: version
         run: |
-          echo "::set-output name=number::${VERSION:1}"
+          echo "::set-output name=number::${VERSION##*/v}"
         env:
           VERSION: ${{ github.ref }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,3 +30,38 @@ jobs:
           GOOS: linux
           GOARCH: amd64
           CGO_ENABLED: 1
+
+      # TODO: add to release
+      - uses: actions/upload-artifact@v2
+        with:
+          name: authn-linux64
+          path: dist/authn-linux64
+
+  windows64:
+    name: Compile for Windows64
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ^1.15
+      - run: go mod download
+      - run: sudo apt install mingw-w64
+
+      - name: compile
+        run: |
+          go build \
+            -ldflags '-X main.VERSION=$(VERSION)' \
+            -o dist/authn-windows64
+        env:
+          GOOS: windows
+          GOARCH: amd64
+          CGO_ENABLED: 1
+          CC: x86_64-w64-mingw32-gcc
+
+      # TODO: add to release
+      - uses: actions/upload-artifact@v2
+        with:
+          name: authn-windows64
+          path: dist/authn-windows64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,9 @@
 name: Release
 
-# TODO
-# on:
-#   release:
-#     types: [created]
-on: push
+on:
+  push:
+    tags:
+      - "v*"
 
 jobs:
   linux64:
@@ -21,7 +20,7 @@ jobs:
       - name: compile
         run: |
           go build \
-            -ldflags '-extldflags -static -X main.VERSION=${VERSION}' \
+            -ldflags '-extldflags -static -X main.VERSION=${VERSION:1}' \
             -o dist/authn-linux64
         env:
           VERSION: ${{ github.ref }}
@@ -50,7 +49,7 @@ jobs:
       - name: compile
         run: |
           go build \
-            -ldflags '-X main.VERSION=${VERSION}' \
+            -ldflags '-X main.VERSION=${VERSION:1}' \
             -o dist/authn-windows64
         env:
           VERSION: ${{ github.ref }}
@@ -79,7 +78,7 @@ jobs:
       - name: compile
         run: |
           go build \
-            -ldflags "-X main.VERSION=${VERSION}" \
+            -ldflags "-X main.VERSION=${VERSION:1}" \
             -o dist/authn-macos64
         env:
           VERSION: ${{ github.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,7 +115,6 @@ jobs:
           tag_name: ${{ github.ref }}
           release_name: ${{ github.ref }}
           draft: true
-          prerelease: true # TODO: toggle before merge
 
       - name: Upload Linux64
         uses: actions/upload-release-asset@v1
@@ -146,3 +145,42 @@ jobs:
           asset_path: ./authn-macos64.bz2/authn-macos64.bz2
           asset_name: authn-macos64.bz2
           asset_content_type: application/x-bzip2
+
+  register:
+    name: Register on Docker Hub
+    runs-on: ubuntu-latest
+    needs: release
+    steps:
+      - name: Get Dockerfile
+        uses: actions/checkout@v2
+
+      - uses: actions/download-artifact@v2
+        with:
+          name: authn-linux64.bz2
+
+      - name: Uncompress
+        run: |
+          bzip2 -d authn-linux64.bz2
+          mkdir dist
+          mv authn-linux64 dist
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: VERSION
+        id: version
+        run: |
+          echo "::set-output name=number::${VERSION:1}"
+        env:
+          VERSION: ${{ github.ref }}
+
+      - name: Push to Docker Hub
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: |
+            keratin/authn-server:latest
+            keratin/authn-server:${{ steps.version.outputs.number }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Release
+
+# TODO
+# on:
+#   release:
+#     types: [created]
+on: push
+
+jobs:
+  linux64:
+    name: Compile for Linux64
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ^1.15
+      - run: go mod download
+
+      - name: release version
+        run: echo ${GITHUB_REF}
+
+      - name: compile
+        run: |
+          go build \
+            -ldflags '-extldflags -static -X main.VERSION=${GITHUB_REF}' \
+            -o dist/authn-linux64
+        env:
+          GOOS: linux
+          GOARCH: amd64
+          CGO_ENABLED: 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,12 +164,6 @@ jobs:
           mkdir dist
           mv authn-linux64 dist
 
-      - name: Login to DockerHub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
       - name: VERSION
         id: version
         run: |
@@ -178,9 +172,9 @@ jobs:
           VERSION: ${{ github.ref }}
 
       - name: Push to Docker Hub
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v1
         with:
-          push: true
-          tags: |
-            keratin/authn-server:latest
-            keratin/authn-server:${{ steps.version.outputs.number }}
+          repository: keratin/authn-server
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          tags: latest,${{ steps.version.outputs.number }}

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 ORG := keratin
 PROJECT := authn-server
 NAME := $(ORG)/$(PROJECT)
-VERSION := 1.10.2
+VERSION := TEST
 MAIN := main.go
 
 .PHONY: clean
@@ -11,47 +11,6 @@ clean:
 init:
 	which ego > /dev/null || go get github.com/benbjohnson/ego/cmd/ego
 	ego server/views
-
-# The Linux builder is a Docker container because that's the easiest way to get the toolchain for
-# CGO on a MacOS host.
-.PHONY: linux-builder
-linux-builder:
-	docker build -f Dockerfile.linux -t $(NAME)-linux-builder .
-
-# The Linux target is built using a special Docker image, because this Makefile assumes the host
-# machine is running MacOS.
-dist/authn-linux64: init
-	make linux-builder
-	docker run --rm \
-		-v $(PWD):/go/src/github.com/$(NAME) \
-		-w /go/src/github.com/$(NAME) \
-		$(NAME)-linux-builder \
-		sh -c " \
-			GOOS=linux GOARCH=amd64 CGO_ENABLED=1 go build -ldflags '-extldflags -static -X main.VERSION=$(VERSION)' -o '$@' \
-		"
-	bzip2 -c "$@" > dist/authn-linux64.bz2
-
-# The Darwin target is built using the host machine. Only runs on a MacOS host.
-dist/authn-macos64: init
-ifeq ($(shell uname -s),Darwin)
-	GOOS=darwin GOARCH=amd64 CGO_ENABLED=1 go build -ldflags "-X main.VERSION=$(VERSION)" -o "$@"
-	bzip2 -c "$@" > dist/authn-macos64.bz2
-endif
-
-# The Windows target is built using Mingw-w64.
-# MacOS: brew install mingw-w64
-# Linux: apt install mingw-w64
-dist/authn-windows64.exe: init
-	GOOS=windows GOARCH=amd64 CGO_ENABLED=1 CC=x86_64-w64-mingw32-gcc go build -ldflags '-X main.VERSION=$(VERSION)' -o '$@'
-
-# The Docker target wraps the linux/amd64 binary
-.PHONY: dist/docker
-dist/docker: dist/authn-linux64
-	docker build --tag $(NAME):latest .
-
-# Build all distributables
-.PHONY: dist
-dist: dist/docker dist/authn-macos64 dist/authn-linux64 dist/authn-windows64.exe
 
 # Run the server
 .PHONY: server
@@ -89,12 +48,8 @@ migrate:
 
 # Cut a release of the current version.
 .PHONY: release
-release: dist
-	docker push $(NAME):latest
-	docker tag $(NAME):latest $(NAME):$(VERSION)
-	docker push $(NAME):$(VERSION)
+release:
 	git push
 	git tag v$(VERSION)
 	git push --tags
-	xdg-open https://github.com/$(NAME)/releases/tag/v$(VERSION)
-	xdg-open dist
+	open https://github.com/$(NAME)/releases/tag/v$(VERSION)


### PR DESCRIPTION
Move release complexity from development machines to GitHub Actions. This is more repeatable and maintainable.