### PR TITLE
migrate to fix case sensitive usernames

### DIFF
--- a/app/data/mock/account_store.go
+++ b/app/data/mock/account_store.go
@@ -2,6 +2,7 @@ package mock
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/keratin/authn-server/app/models"
@@ -42,7 +43,7 @@ func (s *accountStore) Find(id int) (*models.Account, error) {
 }
 
 func (s *accountStore) FindByUsername(u string) (*models.Account, error) {
-	id := s.idByUsername[u]
+	id := s.idByUsername[strings.ToLower(u)]
 	if id == 0 {
 		return nil, nil
 	}
@@ -60,7 +61,7 @@ func (s *accountStore) FindByOauthAccount(provider string, providerID string) (*
 }
 
 func (s *accountStore) Create(u string, p []byte) (*models.Account, error) {
-	if s.idByUsername[u] != 0 {
+	if s.idByUsername[strings.ToLower(u)] != 0 {
 		return nil, Error{ErrNotUnique}
 	}
 
@@ -74,7 +75,7 @@ func (s *accountStore) Create(u string, p []byte) (*models.Account, error) {
 		UpdatedAt:         now,
 	}
 	s.accountsByID[acc.ID] = &acc
-	s.idByUsername[acc.Username] = acc.ID
+	s.idByUsername[strings.ToLower(acc.Username)] = acc.ID
 	return dupAccount(acc), nil
 }
 
@@ -114,7 +115,7 @@ func (s *accountStore) Archive(id int) (bool, error) {
 		return false, nil
 	}
 
-	delete(s.idByUsername, account.Username)
+	delete(s.idByUsername, strings.ToLower(account.Username))
 	now := time.Now()
 	account.Username = ""
 	account.Password = []byte("")
@@ -176,18 +177,19 @@ func (s *accountStore) SetPassword(id int, p []byte) (bool, error) {
 }
 
 func (s *accountStore) UpdateUsername(id int, u string) (bool, error) {
+	uNormalized := strings.ToLower(u)
 	account := s.accountsByID[id]
 	if account == nil {
 		return false, nil
 	}
 
-	if s.idByUsername[u] != 0 && s.idByUsername[u] != id {
+	if s.idByUsername[uNormalized] != 0 && s.idByUsername[uNormalized] != id {
 		return false, Error{ErrNotUnique}
 	}
 
 	account.Username = u
 	account.UpdatedAt = time.Now()
-	s.idByUsername[u] = account.ID
+	s.idByUsername[uNormalized] = account.ID
 	return true, nil
 }
 

--- a/app/data/postgres/migrations.go
+++ b/app/data/postgres/migrations.go
@@ -11,6 +11,7 @@ func MigrateDB(db *sqlx.DB) error {
 		migrateAccounts,
 		createOauthAccounts,
 		createAccountLastLoginAtField,
+		caseInsensitiveUsername,
 	}
 	for _, m := range migrations {
 		if err := m(db); err != nil {
@@ -56,6 +57,14 @@ func createOauthAccounts(db *sqlx.DB) error {
 func createAccountLastLoginAtField(db *sqlx.DB) error {
 	_, err := db.Exec(`
         ALTER TABLE accounts ADD COLUMN IF NOT EXISTS last_login_at timestamptz DEFAULT NULL
+    `)
+	return err
+}
+
+func caseInsensitiveUsername(db *sqlx.DB) error {
+	_, err := db.Exec(`
+        CREATE EXTENSION IF NOT EXISTS citext;
+        ALTER TABLE accounts ALTER COLUMN username TYPE CITEXT;
     `)
 	return err
 }

--- a/app/data/testers/account_store_testers.go
+++ b/app/data/testers/account_store_testers.go
@@ -53,6 +53,14 @@ func testCreate(t *testing.T, store data.AccountStore) {
 		t.Errorf("expected uniqueness error, got %T %v", err, err)
 	}
 
+	account, err = store.Create("AUTHN@KERATIN.TECH", []byte("password"))
+	if account != nil {
+		assert.NotEqual(t, nil, account)
+	}
+	if !data.IsUniquenessError(err) {
+		t.Errorf("expected uniqueness error, got %T %v", err, err)
+	}
+
 	// Assert that db connections are released to pool
 	assert.Equal(t, 1, getOpenConnectionCount(store))
 }
@@ -66,6 +74,10 @@ func testFindByUsername(t *testing.T, store data.AccountStore) {
 	require.NoError(t, err)
 
 	account, err = store.FindByUsername("authn@keratin.tech")
+	assert.NoError(t, err)
+	assert.NotNil(t, account)
+
+	account, err = store.FindByUsername("AUTHN@KERATIN.TECH")
 	assert.NoError(t, err)
 	assert.NotNil(t, account)
 


### PR DESCRIPTION
Only the MySQL database implements the desired case insensitive username behavior by default. Postgres and SQLite migrated to match.

The included migrations will fail if any records exist which are different only by case.

This does not add support for case insensitive Unicode characters (`à` and `À` are still different).

Fixes #169.

