### PR TITLE
Update AUTHN_URL Documentation

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -19,7 +19,7 @@
 |           |    |
 | --------- | --- |
 | Required? | Yes |
-| Value | URL |
+| Value | URL. Must include scheme (http:// or https://) |
 
 This specifies the base URL of the AuthN service. It will be embedded in all issued JWTs as the `iss`. Clients will depend on this information to find and fetch the service's public key when verifying JWTs.
 


### PR DESCRIPTION
In setting up keratin, I have found that if you do not include the scheme with your `AUTHN_URL`, the application will only return 404 errors. The fact that it returns 404s for everything if this is not configured properly seems like a good task to investigate