### PR TITLE
improve validation of ENV urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## HEAD
 
+### Fixed
+
+* Improved validation for AUTHN_URL and other ENV url values [#178]
+
 ## 1.10.4
 
 ### Fixed

--- a/app/config.go
+++ b/app/config.go
@@ -116,7 +116,7 @@ var configurers = []configurer{
 	//
 	// example: https://app.domain.com/authn
 	func(c *Config) error {
-		val, err := lookupURL("AUTHN_URL")
+		val, err := LookupURL("AUTHN_URL")
 		if err == nil {
 			if val == nil {
 				return ErrMissingEnvVar("AUTHN_URL")
@@ -207,7 +207,7 @@ var configurers = []configurer{
 	//
 	// Example: sqlite3://localhost/authn-go
 	func(c *Config) error {
-		val, err := lookupURL("DATABASE_URL")
+		val, err := LookupURL("DATABASE_URL")
 		if err == nil {
 			if val == nil {
 				return ErrMissingEnvVar("DATABASE_URL")
@@ -222,7 +222,7 @@ var configurers = []configurer{
 	//
 	// Example: redis://127.0.0.1:6379/11
 	func(c *Config) error {
-		val, err := lookupURL("REDIS_URL")
+		val, err := LookupURL("REDIS_URL")
 		if err == nil {
 			c.RedisURL = val
 		}
@@ -351,7 +351,7 @@ var configurers = []configurer{
 	// For security, this URL should specify https and include a basic auth username
 	// and password.
 	func(c *Config) error {
-		val, err := lookupURL("APP_PASSWORD_CHANGED_URL")
+		val, err := LookupURL("APP_PASSWORD_CHANGED_URL")
 		if err == nil && val != nil {
 			c.AppPasswordChangedURL = val
 		}
@@ -365,7 +365,7 @@ var configurers = []configurer{
 	// For security, this URL should specify https and include a basic auth username
 	// and password.
 	func(c *Config) error {
-		val, err := lookupURL("APP_PASSWORD_RESET_URL")
+		val, err := LookupURL("APP_PASSWORD_RESET_URL")
 		if err == nil && val != nil {
 			c.AppPasswordResetURL = val
 		}
@@ -379,7 +379,7 @@ var configurers = []configurer{
 	// For security, this URL should specify https and include a basic auth username
 	// and password.
 	func(c *Config) error {
-		val, err := lookupURL("APP_PASSWORDLESS_TOKEN_URL")
+		val, err := LookupURL("APP_PASSWORDLESS_TOKEN_URL")
 		if err == nil && val != nil {
 			c.AppPasswordlessTokenURL = val
 		}

--- a/app/env.go
+++ b/app/env.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 	"regexp"
@@ -37,9 +38,16 @@ func lookupBool(name string, def bool) (bool, error) {
 	return def, nil
 }
 
-func lookupURL(name string) (*url.URL, error) {
+func LookupURL(name string) (*url.URL, error) {
 	if val, ok := os.LookupEnv(name); ok {
-		return url.Parse(val)
+		url, err := url.ParseRequestURI(val)
+		if err == nil {
+			if url.Scheme != "http" && url.Scheme != "https" {
+				return nil, fmt.Errorf("unsupported URL: %v", val)
+			}
+			return url, nil
+		}
+		return nil, err
 	}
 	return nil, nil
 }

--- a/app/env_test.go
+++ b/app/env_test.go
@@ -1,0 +1,55 @@
+package app_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/keratin/authn-server/app"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLookupURL(t *testing.T) {
+	envName := "TEST_LOOKUP_URL"
+
+	t.Run("failing cases", func(t *testing.T) {
+		for _, tc := range []struct {
+			env string
+		}{
+			{"host.domain.com"},
+			{"host.domain.com/path"},
+			{"host.domain.com:1234"},
+			{"host.domain.com:1234/path"},
+		} {
+			err := os.Setenv(envName, tc.env)
+			require.NoError(t, err)
+
+			_, err = app.LookupURL(envName)
+			assert.Error(t, err, tc.env)
+		}
+	})
+
+	t.Run("passing cases", func(t *testing.T) {
+		for _, tc := range []struct {
+			env    string
+			scheme string
+			port   string
+			path   string
+		}{
+			{"https://host.domain.com", "https", "", ""},
+			{"http://host.domain.com:1234/path", "http", "1234", "/path"},
+		} {
+			err := os.Setenv(envName, tc.env)
+			require.NoError(t, err)
+
+			url, err := app.LookupURL(envName)
+			require.NoError(t, err)
+
+			require.Equal(t, "host.domain.com", url.Hostname(), tc.env)
+			assert.Equal(t, tc.scheme, url.Scheme)
+			assert.Equal(t, tc.port, url.Port())
+			assert.Equal(t, tc.path, url.Path)
+		}
+	})
+
+}


### PR DESCRIPTION
The validation for URLs found in ENV variables was lacking, as observed in https://github.com/keratin/authn-server/pull/176#issuecomment-826499034. This imports the relevant test cases and makes them pass with the help of the recommended `url.ParseRequestURI` (and some extra help).