### PR TITLE
Update docs to match zxcvbn password policy scale

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -318,7 +318,7 @@ If you need to restrict account creation to specific email domains, declare the 
 |           |    |
 | --------- | --- |
 | Required? | No |
-| Value | 0 - 5 |
+| Value | 0 - 4 |
 | Default | 2 |
 
 * 0 - too guessable


### PR DESCRIPTION
Correct docs to show possible values for `PASSWORD_POLICY_SCORE` to be `0 - 4` instead of `0 - 5` to be in line with range used by [zxcvbn](https://github.com/dropbox/zxcvbn#usage).