### PR TITLE
app: permit redis with TLS enabled

### DIFF
--- a/app/env.go
+++ b/app/env.go
@@ -10,6 +10,16 @@ import (
 
 type ErrMissingEnvVar string
 
+var supportedSchemes = map[string]struct{}{
+	"http":     {},
+	"https":    {},
+	"mysql":    {},
+	"sqlite3":  {},
+	"postgres": {},
+	"redis":    {},
+	"rediss":   {},
+}
+
 func (name ErrMissingEnvVar) Error() string {
 	return "missing environment variable: " + string(name)
 }
@@ -42,7 +52,7 @@ func LookupURL(name string) (*url.URL, error) {
 	if val, ok := os.LookupEnv(name); ok {
 		url, err := url.ParseRequestURI(val)
 		if err == nil {
-			if url.Scheme != "http" && url.Scheme != "https" && url.Scheme != "mysql" && url.Scheme != "sqlite3" && url.Scheme != "postgres" && url.Scheme != "redis" {
+			if _, ok := supportedSchemes[url.Scheme]; !ok {
 				return nil, fmt.Errorf("unsupported URL: %v", val)
 			}
 			return url, nil


### PR DESCRIPTION
This patch updates the supported schemes check with support for `rediss://` URLs.

Closes https://github.com/keratin/authn-server/issues/185.