### PR TITLE
feat: Add last_login_at and password_reset_at to account API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## HEAD
 
+* Added `last_login_at` and `password_changed_at` to Get Account API
+
 ## 1.13.0
 
 ### Added

--- a/docs/api.md
+++ b/docs/api.md
@@ -138,6 +138,8 @@ Visibility: Private
       "result": {
         "id": <id>,
         "username": "...",
+        "last_login_at": "2006-01-02T15:04:05Z07:00",
+        "password_changed_at": "2006-01-02T15:04:05Z07:00",
         "locked": false,
         "deleted": false
       }

--- a/server/handlers/get_account.go
+++ b/server/handlers/get_account.go
@@ -28,11 +28,17 @@ func GetAccount(app *app.App) http.HandlerFunc {
 		}
 
 		WriteData(w, http.StatusOK, map[string]interface{}{
-			"id":                  account.ID,
-			"username":            account.Username,
-			"locked":              account.Locked,
-			"password_changed_at": account.PasswordChangedAt,
-			"last_login_at":       account.LastLoginAt,
+			"id":       account.ID,
+			"username": account.Username,
+			"locked":   account.Locked,
+			"last_login_at": func() string {
+				if account.LastLoginAt != nil {
+					return account.LastLoginAt.String()
+				} else {
+					return ""
+				}
+			},
+			"password_changed_at": account.PasswordChangedAt.String(),
 			"deleted":             account.DeletedAt != nil,
 		})
 	}

--- a/server/handlers/get_account.go
+++ b/server/handlers/get_account.go
@@ -31,8 +31,8 @@ func GetAccount(app *app.App) http.HandlerFunc {
 			"id":                  account.ID,
 			"username":            account.Username,
 			"locked":              account.Locked,
-			"password_changed_at": account.PasswordChangedAt.String(),
-			"last_login_at":       account.LastLoginAt.String(),
+			"password_changed_at": account.PasswordChangedAt,
+			"last_login_at":       account.LastLoginAt,
 			"deleted":             account.DeletedAt != nil,
 		})
 	}

--- a/server/handlers/get_account.go
+++ b/server/handlers/get_account.go
@@ -28,10 +28,12 @@ func GetAccount(app *app.App) http.HandlerFunc {
 		}
 
 		WriteData(w, http.StatusOK, map[string]interface{}{
-			"id":       account.ID,
-			"username": account.Username,
-			"locked":   account.Locked,
-			"deleted":  account.DeletedAt != nil,
+			"id":                  account.ID,
+			"username":            account.Username,
+			"locked":              account.Locked,
+			"password_changed_at": account.PasswordChangedAt.String(),
+			"last_login_at":       account.LastLoginAt.String(),
+			"deleted":             account.DeletedAt != nil,
 		})
 	}
 }

--- a/server/handlers/get_account.go
+++ b/server/handlers/get_account.go
@@ -27,18 +27,26 @@ func GetAccount(app *app.App) http.HandlerFunc {
 			panic(err)
 		}
 
+		var formattedLastLogin string
+		if account.LastLoginAt == nil {
+			formattedLastLogin = ""
+		} else {
+			formattedLastLogin = account.LastLoginAt.String()
+		}
+
+		var formattedPasswordChangedAt string
+		if account.PasswordChangedAt.IsZero() {
+			formattedPasswordChangedAt = ""
+		} else {
+			formattedPasswordChangedAt = account.PasswordChangedAt.String()
+		}
+
 		WriteData(w, http.StatusOK, map[string]interface{}{
-			"id":       account.ID,
-			"username": account.Username,
-			"locked":   account.Locked,
-			"last_login_at": func() string {
-				if account.LastLoginAt != nil {
-					return account.LastLoginAt.String()
-				} else {
-					return ""
-				}
-			},
-			"password_changed_at": account.PasswordChangedAt.String(),
+			"id":                  account.ID,
+			"username":            account.Username,
+			"locked":              account.Locked,
+			"last_login_at":       formattedLastLogin,
+			"password_changed_at": formattedPasswordChangedAt,
 			"deleted":             account.DeletedAt != nil,
 		})
 	}

--- a/server/handlers/get_account.go
+++ b/server/handlers/get_account.go
@@ -31,22 +31,22 @@ func GetAccount(app *app.App) http.HandlerFunc {
 		if account.LastLoginAt == nil {
 			formattedLastLogin = ""
 		} else {
-			formattedLastLogin = account.LastLoginAt.String()
+			formattedLastLogin = account.LastLoginAt.Format("2006-01-02T15:04:05Z07:00")
 		}
 
 		var formattedPasswordChangedAt string
 		if account.PasswordChangedAt.IsZero() {
 			formattedPasswordChangedAt = ""
 		} else {
-			formattedPasswordChangedAt = account.PasswordChangedAt.String()
+			formattedPasswordChangedAt = account.PasswordChangedAt.Format("2006-01-02T15:04:05Z07:00")
 		}
 
 		WriteData(w, http.StatusOK, map[string]interface{}{
 			"id":                  account.ID,
 			"username":            account.Username,
-			"locked":              account.Locked,
 			"last_login_at":       formattedLastLogin,
 			"password_changed_at": formattedPasswordChangedAt,
+			"locked":              account.Locked,
 			"deleted":             account.DeletedAt != nil,
 		})
 	}

--- a/server/handlers/get_account.go
+++ b/server/handlers/get_account.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/gorilla/mux"
 	"github.com/keratin/authn-server/app"
@@ -27,18 +28,14 @@ func GetAccount(app *app.App) http.HandlerFunc {
 			panic(err)
 		}
 
-		var formattedLastLogin string
-		if account.LastLoginAt == nil {
-			formattedLastLogin = ""
-		} else {
-			formattedLastLogin = account.LastLoginAt.Format("2006-01-02T15:04:05Z07:00")
+		formattedLastLogin := ""
+		if account.LastLoginAt != nil {
+			formattedLastLogin = account.LastLoginAt.Format(time.RFC3339)
 		}
 
-		var formattedPasswordChangedAt string
-		if account.PasswordChangedAt.IsZero() {
-			formattedPasswordChangedAt = ""
-		} else {
-			formattedPasswordChangedAt = account.PasswordChangedAt.Format("2006-01-02T15:04:05Z07:00")
+		formattedPasswordChangedAt := ""
+		if !account.PasswordChangedAt.IsZero() {
+			formattedPasswordChangedAt = account.PasswordChangedAt.Format(time.RFC3339)
 		}
 
 		WriteData(w, http.StatusOK, map[string]interface{}{

--- a/server/handlers/get_account_test.go
+++ b/server/handlers/get_account_test.go
@@ -5,9 +5,9 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/keratin/authn-server/server/test"
-	"github.com/keratin/authn-server/lib/route"
 	"github.com/keratin/authn-server/app/models"
+	"github.com/keratin/authn-server/lib/route"
+	"github.com/keratin/authn-server/server/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -46,16 +46,20 @@ func assertGetAccountResponse(t *testing.T, res *http.Response, acc *models.Acco
 	// check that the response contains the expected json
 	assert.Equal(t, []string{"application/json"}, res.Header["Content-Type"])
 	responseData := struct {
-		ID       int    `json:"id"`
-		Username string `json:"username"`
-		Locked   bool   `json:"locked"`
-		Deleted  bool   `json:"deleted_at"`
+		ID                int    `json:"id"`
+		Username          string `json:"username"`
+		Locked            bool   `json:"locked"`
+		PasswordChangedAt string `json:"password_changed_at"`
+		LastLoginAt       string `json:"last_login_at"`
+		Deleted           bool   `json:"deleted_at"`
 	}{}
 	err := test.ExtractResult(res, &responseData)
 	assert.NoError(t, err)
 
 	assert.Equal(t, acc.Username, responseData.Username)
 	assert.Equal(t, acc.ID, responseData.ID)
+	assert.Equal(t, acc.PasswordChangedAt.String(), responseData.PasswordChangedAt)
+	assert.Equal(t, acc.LastLoginAt.String(), responseData.LastLoginAt)
 	assert.Equal(t, false, responseData.Locked)
 	assert.Equal(t, false, responseData.Deleted)
 }

--- a/server/handlers/get_account_test.go
+++ b/server/handlers/get_account_test.go
@@ -48,9 +48,9 @@ func assertGetAccountResponse(t *testing.T, res *http.Response, acc *models.Acco
 	responseData := struct {
 		ID                int    `json:"id"`
 		Username          string `json:"username"`
-		Locked            bool   `json:"locked"`
-		PasswordChangedAt string `json:"password_changed_at"`
 		LastLoginAt       string `json:"last_login_at"`
+		PasswordChangedAt string `json:"password_changed_at"`
+		Locked            bool   `json:"locked"`
 		Deleted           bool   `json:"deleted_at"`
 	}{}
 	err := test.ExtractResult(res, &responseData)
@@ -58,8 +58,9 @@ func assertGetAccountResponse(t *testing.T, res *http.Response, acc *models.Acco
 
 	assert.Equal(t, acc.Username, responseData.Username)
 	assert.Equal(t, acc.ID, responseData.ID)
-	assert.Equal(t, acc.PasswordChangedAt.String(), responseData.PasswordChangedAt)
-	assert.Equal(t, acc.LastLoginAt.String(), responseData.LastLoginAt)
+	// NOTE: acc.LastLoginAt is empty so the API returns an empty response
+	assert.Equal(t, "", responseData.LastLoginAt)
+	assert.Equal(t, acc.PasswordChangedAt.Format("2006-01-02T15:04:05Z07:00"), responseData.PasswordChangedAt)
 	assert.Equal(t, false, responseData.Locked)
 	assert.Equal(t, false, responseData.Deleted)
 }


### PR DESCRIPTION
### Whats Up
Add `last_login_at` and `password_reset_at` to Account API. This closes #194 

FYI, I'm very new to go, so please pardon any formatting or syntax oddities. I'm used to ruby and so I assume there's a simpler way to implement what I did, but just don't know Go very well