### PR TITLE
dep: record ego as tooling dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.db
 .env
-vendor/
-dist/
 .idea
+bin
+dist/
+vendor/

--- a/Makefile
+++ b/Makefile
@@ -5,13 +5,17 @@ NAME := $(ORG)/$(PROJECT)
 VERSION := 1.15.0
 MAIN := main.go
 
+BIN := $(shell pwd)/bin
+export GOBIN := $(BIN)
+export PATH := $(BIN):$(PATH)
+
 .PHONY: clean
 clean:
 	rm -rf dist
 
-init:
+init: $(BIN)/ego
 	go install
-	ego server/views
+	$(BIN)/ego server/views
 
 # Run the server
 .PHONY: server
@@ -57,3 +61,6 @@ release:
 	git tag v$(VERSION)
 	git push --tags
 	open https://github.com/$(NAME)/releases/tag/v$(VERSION)
+
+$(BIN)/ego:
+	go install github.com/benbjohnson/ego/...

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.13
 require (
 	cloud.google.com/go v0.0.0-20180417120045-d19004dbbee5 // indirect
 	github.com/airbrake/gobrake v3.5.0+incompatible
-	github.com/benbjohnson/ego v0.4.3 // indirect
+	github.com/benbjohnson/ego v0.4.3
 	github.com/beorn7/perks v0.0.0-20160804104726-4c0e84591b9a // indirect
 	github.com/dlclark/regexp2 v1.1.6 // indirect
 	github.com/felixge/httpsnoop v1.0.0

--- a/tools.go
+++ b/tools.go
@@ -1,0 +1,8 @@
+//go:build tools
+// +build tools
+
+package tools
+
+import (
+	_ "github.com/benbjohnson/ego"
+)


### PR DESCRIPTION
Reported at
https://github.com/keratin/authn-server/pull/198#issuecomment-1092440793:

> Took me a moment to uncover the problem but this appears to be a
> different "ego" library. AuthN relies on go get
> github.com/benbjohnson/ego instead. That used to be part of the
> go.mod list until a recent PR.

Add a tools.go to record the tooling dependency per guidance:
https://github.com/golang/go/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module. This
ensures ego sticks around when authn-server's dependencies are
modified.