### PR TITLE
tooling: setup golangci-lint locally (fixes #102)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,4 @@
+linters:
+  disable-all: true
+  enable:
+    - gosec  

--- a/Makefile
+++ b/Makefile
@@ -72,5 +72,5 @@ docker-local:
 
 # Run configured linters
 lint:
-	@which golangci-lint > /dev/null || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH)/bin v1.53.3
+	@which golangci-lint > /dev/null || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH)/bin
 	golangci-lint run --config .golangci.yml

--- a/Makefile
+++ b/Makefile
@@ -69,3 +69,8 @@ $(BIN)/ego:
 # TODO: look into buildx support for multi-arch builds
 docker-local:
 	docker build . -t $(NAME):local -f Dockerfile.local
+
+# Run configured linters
+lint:
+	@which golangci-lint > /dev/null || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH)/bin v1.53.3
+	golangci-lint run --config .golangci.yml

--- a/app/data/private/key_test.go
+++ b/app/data/private/key_test.go
@@ -4,14 +4,16 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
-	"github.com/keratin/authn-server/app/data/private"
 	"math/rand"
 	"testing"
+
+	"github.com/keratin/authn-server/app/data/private"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
+// nolint: gosec
 func TestNewKey(t *testing.T) {
 	rnd := rand.New(rand.NewSource(1234))
 	rsaKey, err := rsa.GenerateKey(rnd, 256)

--- a/app/data/sqlite3/blob_store.go
+++ b/app/data/sqlite3/blob_store.go
@@ -2,7 +2,6 @@ package sqlite3
 
 import (
 	"database/sql"
-	"math/rand"
 	"time"
 
 	"github.com/jmoiron/sqlx"
@@ -21,7 +20,7 @@ type BlobStore struct {
 
 func (s *BlobStore) Clean(reporter ops.ErrorReporter) {
 	go func() {
-		for range time.Tick(time.Minute + time.Duration(rand.Intn(5))*time.Second) {
+		for range time.Tick(time.Minute + jitter()) {
 			_, err := s.DB.Exec("DELETE FROM blobs WHERE expires_at < ?", time.Now())
 			if err != nil {
 				reporter.ReportError(errors.Wrap(err, "BlobStore Clean"))

--- a/app/data/sqlite3/refresh_token_store.go
+++ b/app/data/sqlite3/refresh_token_store.go
@@ -3,15 +3,14 @@ package sqlite3
 import (
 	"database/sql"
 	"encoding/hex"
-	"math/rand"
 	"time"
 
 	"github.com/keratin/authn-server/ops"
 	"github.com/pkg/errors"
 
 	"github.com/jmoiron/sqlx"
-	"github.com/keratin/authn-server/lib"
 	"github.com/keratin/authn-server/app/models"
+	"github.com/keratin/authn-server/lib"
 )
 
 type RefreshTokenStore struct {
@@ -21,7 +20,7 @@ type RefreshTokenStore struct {
 
 func (s *RefreshTokenStore) Clean(reporter ops.ErrorReporter) {
 	go func() {
-		for range time.Tick(time.Minute + time.Duration(rand.Intn(5))*time.Second) {
+		for range time.Tick(time.Minute + jitter()) {
 			_, err := s.Exec("DELETE FROM refresh_tokens WHERE expires_at < ?", time.Now())
 			if err != nil {
 				reporter.ReportError(errors.Wrap(err, "RefreshTokenStore Clean"))

--- a/app/data/sqlite3/util.go
+++ b/app/data/sqlite3/util.go
@@ -1,0 +1,11 @@
+package sqlite3
+
+import (
+	"math/rand"
+	"time"
+)
+
+func jitter() time.Duration {
+	// nolint: gosec
+	return time.Duration(rand.Intn(5)) * time.Second
+}

--- a/app/services/password_resetter_test.go
+++ b/app/services/password_resetter_test.go
@@ -56,6 +56,7 @@ func TestPasswordResetter(t *testing.T) {
 	})
 
 	t.Run("when token is invalid", func(t *testing.T) {
+		// nolint: gosec
 		token := "not.valid.jwt"
 
 		err := invoke(token, "0a0b0c0d0e0f")

--- a/app/services/passwordless_token_verifier_test.go
+++ b/app/services/passwordless_token_verifier_test.go
@@ -37,6 +37,7 @@ func TestPasswordlessTokenVerifier(t *testing.T) {
 	}
 
 	t.Run("when token is invalid", func(t *testing.T) {
+		// nolint: gosec
 		token := "not.valid.jwt"
 
 		err := invoke(token)


### PR DESCRIPTION
- only runs `gosec` linter
- adds `make lint` target
- does not attempt to integrate with CI