### PR TITLE
tooling: add gosimple + govet linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,9 +1,3 @@
 linters:
-  disable-all: true
   enable:
     - gosec
-    - errcheck
-    - staticcheck
-    - unused
-    - ineffassign
-    - govet

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,3 +6,4 @@ linters:
     - staticcheck
     - unused
     - ineffassign
+    - govet

--- a/app/data/key_store_rotater_test.go
+++ b/app/data/key_store_rotater_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestKeyStoreRotater(t *testing.T) {
-	reporter := &ops.LogReporter{logrus.New()}
+	reporter := &ops.LogReporter{FieldLogger: logrus.New()}
 	secret := []byte("32bigbytesofsuperultimatesecrecy")
 	interval := time.Hour
 	logger := logrus.New()

--- a/app/services/password_changer_test.go
+++ b/app/services/password_changer_test.go
@@ -24,7 +24,7 @@ func TestPasswordChanger(t *testing.T) {
 	}
 
 	invoke := func(id int, currentPassword string, password string) error {
-		return services.PasswordChanger(accountStore, &ops.LogReporter{logrus.New()}, cfg, id, currentPassword, password)
+		return services.PasswordChanger(accountStore, &ops.LogReporter{FieldLogger: logrus.New()}, cfg, id, currentPassword, password)
 	}
 
 	factory := func(username string, password string) (*models.Account, error) {

--- a/app/services/password_resetter_test.go
+++ b/app/services/password_resetter_test.go
@@ -33,7 +33,7 @@ func TestPasswordResetter(t *testing.T) {
 	}
 
 	invoke := func(token string, password string) error {
-		_, err := services.PasswordResetter(accountStore, &ops.LogReporter{logrus.New()}, cfg, token, password)
+		_, err := services.PasswordResetter(accountStore, &ops.LogReporter{FieldLogger: logrus.New()}, cfg, token, password)
 		return err
 	}
 

--- a/app/services/password_setter_test.go
+++ b/app/services/password_setter_test.go
@@ -20,7 +20,7 @@ func TestPasswordSetter(t *testing.T) {
 	}
 
 	invoke := func(id int, password string) error {
-		return services.PasswordSetter(accountStore, &ops.LogReporter{logrus.New()}, cfg, id, password)
+		return services.PasswordSetter(accountStore, &ops.LogReporter{FieldLogger: logrus.New()}, cfg, id, password)
 	}
 
 	account, err := accountStore.Create("existing@keratin.example.com", []byte("old"))

--- a/app/services/passwordless_token_verifier_test.go
+++ b/app/services/passwordless_token_verifier_test.go
@@ -32,7 +32,7 @@ func TestPasswordlessTokenVerifier(t *testing.T) {
 	}
 
 	invoke := func(token string) error {
-		_, err := services.PasswordlessTokenVerifier(accountStore, &ops.LogReporter{logrus.New()}, cfg, token)
+		_, err := services.PasswordlessTokenVerifier(accountStore, &ops.LogReporter{FieldLogger: logrus.New()}, cfg, token)
 		return err
 	}
 

--- a/app/services/session_creator_test.go
+++ b/app/services/session_creator_test.go
@@ -24,9 +24,9 @@ func TestSessionCreator(t *testing.T) {
 	keyStore := mock.NewKeyStore(rsaKey)
 	refreshStore := mock.NewRefreshTokenStore()
 	accountStore := mock.NewAccountStore()
-	reporter := &ops.LogReporter{logrus.New()}
+	reporter := &ops.LogReporter{FieldLogger: logrus.New()}
 
-	audience := &route.Domain{"authn.example.com", "8080"}
+	audience := &route.Domain{Hostname: "authn.example.com", Port: "8080"}
 	account, err := accountStore.Create("existing", []byte("secret"))
 	require.NoError(t, err)
 

--- a/app/services/session_refresher_test.go
+++ b/app/services/session_refresher_test.go
@@ -26,10 +26,10 @@ func TestSessionRefresher(t *testing.T) {
 		AuthNURL: &url.URL{Scheme: "http", Host: "authn.example.com"},
 	}
 	refreshStore := mock.NewRefreshTokenStore()
-	reporter := &ops.LogReporter{logrus.New()}
+	reporter := &ops.LogReporter{FieldLogger: logrus.New()}
 
 	accountID := 0
-	audience := &route.Domain{"authn.example.com", "8080"}
+	audience := &route.Domain{Hostname: "authn.example.com", Port: "8080"}
 	session, err := sessions.New(refreshStore, cfg, accountID, audience.String())
 	require.NoError(t, err)
 	assert.NotEmpty(t, session.SessionID)

--- a/main.go
+++ b/main.go
@@ -2,14 +2,13 @@ package main
 
 import (
 	"fmt"
+	"os"
+	"path"
 
 	"github.com/keratin/authn-server/app"
 	"github.com/keratin/authn-server/app/data"
 	"github.com/keratin/authn-server/server"
 	"github.com/sirupsen/logrus"
-
-	"os"
-	"path"
 )
 
 // VERSION is a value injected at build time with ldflags
@@ -35,14 +34,14 @@ func main() {
 	} else if cmd == "migrate" {
 		migrate(cfg)
 	} else {
-		os.Stderr.WriteString(fmt.Sprintf("unexpected invocation\n"))
+		os.Stderr.WriteString("unexpected invocation\n")
 		usage()
 		os.Exit(2)
 	}
 }
 
 func serve(cfg *app.Config) {
-	fmt.Println(fmt.Sprintf("~*~ Keratin AuthN v%s ~*~", VERSION))
+	fmt.Printf("~*~ Keratin AuthN v%s ~*~\n", VERSION)
 
 	// Default logger
 	logger := logrus.New()
@@ -56,10 +55,10 @@ func serve(cfg *app.Config) {
 		return
 	}
 
-	fmt.Println(fmt.Sprintf("AUTHN_URL: %s", cfg.AuthNURL))
-	fmt.Println(fmt.Sprintf("PORT: %d", cfg.ServerPort))
+	fmt.Printf("AUTHN_URL: %s\n", cfg.AuthNURL)
+	fmt.Printf("PORT: %d\n", cfg.ServerPort)
 	if app.Config.PublicPort != 0 {
-		fmt.Println(fmt.Sprintf("PUBLIC_PORT: %d", app.Config.PublicPort))
+		fmt.Printf("PUBLIC_PORT: %d\n", app.Config.PublicPort)
 	}
 
 	server.Server(app)
@@ -77,9 +76,10 @@ func migrate(cfg *app.Config) {
 
 func usage() {
 	exe := path.Base(os.Args[0])
-	fmt.Println(fmt.Sprintf(`
+	fmt.Printf(`
 Usage:
 %s server  - run the server (default)
 %s migrate - run migrations
-`, exe, exe))
+
+`, exe, exe)
 }

--- a/server/handlers/envelope.go
+++ b/server/handlers/envelope.go
@@ -45,7 +45,7 @@ func writeParseErrors(w http.ResponseWriter, err parse.Error) {
 }
 
 func WriteNotFound(w http.ResponseWriter, resource string) {
-	WriteJSON(w, http.StatusNotFound, ServiceErrors{Errors: services.FieldErrors{{resource, services.ErrNotFound}}})
+	WriteJSON(w, http.StatusNotFound, ServiceErrors{Errors: services.FieldErrors{{Field: resource, Message: services.ErrNotFound}}})
 }
 
 func WriteJSON(w http.ResponseWriter, httpCode int, d interface{}) {

--- a/server/handlers/envelope.go
+++ b/server/handlers/envelope.go
@@ -25,11 +25,11 @@ func WriteData(w http.ResponseWriter, httpCode int, d interface{}) {
 }
 
 func WriteErrors(w http.ResponseWriter, err error) {
-	switch err.(type) {
+	switch te := err.(type) {
 	case services.FieldErrors:
-		WriteJSON(w, http.StatusUnprocessableEntity, ServiceErrors{Errors: err.(services.FieldErrors)})
+		WriteJSON(w, http.StatusUnprocessableEntity, ServiceErrors{Errors: te})
 	case parse.Error:
-		writeParseErrors(w, err.(parse.Error))
+		writeParseErrors(w, te)
 	default:
 		WriteJSON(w, http.StatusInternalServerError, RequestError{Error: err.Error()})
 	}

--- a/server/handlers/get_accounts_available.go
+++ b/server/handlers/get_accounts_available.go
@@ -17,7 +17,7 @@ func GetAccountsAvailable(app *app.App) http.HandlerFunc {
 		if account == nil {
 			WriteData(w, http.StatusOK, true)
 		} else {
-			WriteErrors(w, services.FieldErrors{{"username", services.ErrTaken}})
+			WriteErrors(w, services.FieldErrors{{Field: "username", Message: services.ErrTaken}})
 		}
 	}
 }

--- a/server/handlers/get_session_refresh_test.go
+++ b/server/handlers/get_session_refresh_test.go
@@ -53,7 +53,7 @@ func BenchmarkGetSessionRefresh(b *testing.B) {
 		testApp := test.App()
 		server := test.Server(testApp)
 		defer server.Close()
-		testApp.RefreshTokenStore = &sqlite3.RefreshTokenStore{sqliteDB, time.Hour}
+		testApp.RefreshTokenStore = &sqlite3.RefreshTokenStore{Ext: sqliteDB, TTL: time.Hour}
 		client := route.NewClient(server.URL).
 			Referred(&testApp.Config.ApplicationDomains[0]).
 			WithCookie(test.CreateSession(testApp.RefreshTokenStore, testApp.Config, 12345))
@@ -73,7 +73,7 @@ func BenchmarkGetSessionRefresh(b *testing.B) {
 		testApp := test.App()
 		server := test.Server(testApp)
 		defer server.Close()
-		testApp.RefreshTokenStore = &redis.RefreshTokenStore{redisDB, time.Hour}
+		testApp.RefreshTokenStore = &redis.RefreshTokenStore{Client: redisDB, TTL: time.Hour}
 		client := route.NewClient(server.URL).
 			Referred(&testApp.Config.ApplicationDomains[0]).
 			WithCookie(test.CreateSession(testApp.RefreshTokenStore, testApp.Config, 12345))
@@ -111,7 +111,7 @@ func TestGetSessionRefreshFailure(t *testing.T) {
 			ApplicationDomains: []route.Domain{{Hostname: "test.com"}},
 		},
 		RefreshTokenStore: mock.NewRefreshTokenStore(),
-		Reporter:          &ops.LogReporter{logrus.New()},
+		Reporter:          &ops.LogReporter{FieldLogger: logrus.New()},
 		Logger:            logrus.New(),
 	}
 	server := test.Server(testApp)

--- a/server/handlers/patch_account_test.go
+++ b/server/handlers/patch_account_test.go
@@ -6,8 +6,8 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/keratin/authn-server/lib/route"
 	"github.com/keratin/authn-server/app/services"
+	"github.com/keratin/authn-server/lib/route"
 
 	"github.com/keratin/authn-server/server/test"
 	"github.com/stretchr/testify/assert"
@@ -61,6 +61,6 @@ func TestPatchAccount(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, http.StatusUnprocessableEntity, res.StatusCode)
-		test.AssertErrors(t, res, services.FieldErrors{{"username", services.ErrMissing}})
+		test.AssertErrors(t, res, services.FieldErrors{{Field: "username", Message: services.ErrMissing}})
 	})
 }

--- a/server/handlers/post_account_test.go
+++ b/server/handlers/post_account_test.go
@@ -79,7 +79,7 @@ func TestPostAccountFailure(t *testing.T) {
 		password string
 		errors   services.FieldErrors
 	}{
-		{"", "", services.FieldErrors{{"username", "MISSING"}, {"password", "MISSING"}}},
+		{"", "", services.FieldErrors{{Field: "username", Message: "MISSING"}, {Field: "password", Message: "MISSING"}}},
 	}
 
 	for _, tc := range testCases {

--- a/server/handlers/post_accounts_import_test.go
+++ b/server/handlers/post_accounts_import_test.go
@@ -64,7 +64,7 @@ func TestPostAccountsImport(t *testing.T) {
 		res, err := client.PostJSON("/accounts/import", map[string]interface{}{
 			"username": "jsonunlocked@app.com",
 			"password": "secret",
-			"locked": "false",
+			"locked":   "false",
 		})
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusCreated, res.StatusCode)
@@ -81,7 +81,7 @@ func TestPostAccountsImport(t *testing.T) {
 		})
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusUnprocessableEntity, res.StatusCode)
-		test.AssertErrors(t, res, services.FieldErrors{{"password", "MISSING"}})
+		test.AssertErrors(t, res, services.FieldErrors{{Field: "password", Message: "MISSING"}})
 	})
 
 }

--- a/server/handlers/post_password_test.go
+++ b/server/handlers/post_password_test.go
@@ -75,7 +75,7 @@ func TestPostPassword(t *testing.T) {
 
 		// does not work
 		assert.Equal(t, http.StatusUnprocessableEntity, res.StatusCode)
-		test.AssertErrors(t, res, services.FieldErrors{{"token", "INVALID_OR_EXPIRED"}})
+		test.AssertErrors(t, res, services.FieldErrors{{Field: "token", Message: "INVALID_OR_EXPIRED"}})
 	})
 
 	t.Run("valid session", func(t *testing.T) {
@@ -120,7 +120,7 @@ func TestPostPassword(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, http.StatusUnprocessableEntity, res.StatusCode)
-		test.AssertErrors(t, res, services.FieldErrors{{"password", "INSECURE"}})
+		test.AssertErrors(t, res, services.FieldErrors{{Field: "password", Message: "INSECURE"}})
 	})
 
 	t.Run("valid session and bad currentPassword", func(t *testing.T) {
@@ -139,7 +139,7 @@ func TestPostPassword(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, http.StatusUnprocessableEntity, res.StatusCode)
-		test.AssertErrors(t, res, services.FieldErrors{{"credentials", "FAILED"}})
+		test.AssertErrors(t, res, services.FieldErrors{{Field: "credentials", Message: "FAILED"}})
 	})
 
 	t.Run("invalid session", func(t *testing.T) {

--- a/server/handlers/post_session_test.go
+++ b/server/handlers/post_session_test.go
@@ -74,7 +74,7 @@ func TestPostSessionFailure(t *testing.T) {
 		password string
 		errors   services.FieldErrors
 	}{
-		{"", "", services.FieldErrors{{"credentials", "FAILED"}}},
+		{"", "", services.FieldErrors{{Field: "credentials", Message: "FAILED"}}},
 	}
 
 	for _, tc := range testCases {

--- a/server/handlers/post_session_token_test.go
+++ b/server/handlers/post_session_token_test.go
@@ -7,12 +7,12 @@ import (
 
 	"golang.org/x/crypto/bcrypt"
 
-	"github.com/keratin/authn-server/server/test"
-	"github.com/keratin/authn-server/lib/route"
 	"github.com/keratin/authn-server/app/models"
 	"github.com/keratin/authn-server/app/services"
 	"github.com/keratin/authn-server/app/tokens/passwordless"
 	"github.com/keratin/authn-server/app/tokens/sessions"
+	"github.com/keratin/authn-server/lib/route"
+	"github.com/keratin/authn-server/server/test"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -73,7 +73,7 @@ func TestPostSessionToken(t *testing.T) {
 
 		// does not work
 		assert.Equal(t, http.StatusUnprocessableEntity, res.StatusCode)
-		test.AssertErrors(t, res, services.FieldErrors{{"token", "INVALID_OR_EXPIRED"}})
+		test.AssertErrors(t, res, services.FieldErrors{{Field: "token", Message: "INVALID_OR_EXPIRED"}})
 	})
 
 	t.Run("valid session", func(t *testing.T) {

--- a/server/server.go
+++ b/server/server.go
@@ -12,7 +12,7 @@ import (
 func Server(app *app.App) {
 	if app.Config.PublicPort != 0 {
 		go func() {
-			fmt.Println(fmt.Sprintf("PUBLIC_PORT: %d", app.Config.PublicPort))
+			fmt.Printf("PUBLIC_PORT: %d\n", app.Config.PublicPort)
 			publicServer := &http.Server{
 				Addr:              fmt.Sprintf(":%d", app.Config.PublicPort),
 				Handler:           PublicRouter(app),

--- a/server/sessions/middleware_test.go
+++ b/server/sessions/middleware_test.go
@@ -26,7 +26,7 @@ func TestSession(t *testing.T) {
 			ApplicationDomains: []route.Domain{{Hostname: "example.com"}},
 		},
 		RefreshTokenStore: mock.NewRefreshTokenStore(),
-		Reporter:          &ops.LogReporter{logrus.New()},
+		Reporter:          &ops.LogReporter{FieldLogger: logrus.New()},
 	}
 
 	t.Run("valid session", func(t *testing.T) {

--- a/server/test/app.go
+++ b/server/test/app.go
@@ -46,7 +46,7 @@ func App() *app.App {
 		AccountStore:      mock.NewAccountStore(),
 		RefreshTokenStore: mock.NewRefreshTokenStore(),
 		Actives:           mock.NewActives(),
-		Reporter:          &ops.LogReporter{logger},
+		Reporter:          &ops.LogReporter{FieldLogger: logger},
 		OauthProviders:    map[string]oauth.Provider{},
 		Logger:            logger,
 	}

--- a/server/test/asserts.go
+++ b/server/test/asserts.go
@@ -21,7 +21,7 @@ func AssertData(t *testing.T, res *http.Response, expected interface{}) {
 	t.Helper()
 	assert.Equal(t, []string{"application/json"}, res.Header["Content-Type"])
 
-	j, err := json.Marshal(handlers.ServiceData{expected})
+	j, err := json.Marshal(handlers.ServiceData{Result: expected})
 	require.NoError(t, err)
 	assert.Equal(t, string(j), string(ReadBody(res)))
 }

--- a/server/test/util.go
+++ b/server/test/util.go
@@ -21,7 +21,7 @@ func ReadBody(res *http.Response) []byte {
 // `inner`, an empty struct that describes the expected (desired) shape of what is inside the
 // envelope.
 func ExtractResult(res *http.Response, inner interface{}) error {
-	return json.Unmarshal(ReadBody(res), &handlers.ServiceData{inner})
+	return json.Unmarshal(ReadBody(res), &handlers.ServiceData{Result: inner})
 }
 
 // ReadCookie gets a cookie by name.


### PR DESCRIPTION
Pretty simple stuff in this one.  The unkeyed fields one is something I've seen burn on a few struct changes.

This gets us to the point of running all default linters + gosec which I think is a good place to be in general.  I've never found a great reason not to keep the defaults enabled even if you need to add a few `// nolint` comments once in awhile.