### PR TITLE
Remove duplicate print of PUBLIC_PORT

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -12,7 +12,6 @@ import (
 func Server(app *app.App) {
 	if app.Config.PublicPort != 0 {
 		go func() {
-			fmt.Printf("PUBLIC_PORT: %d\n", app.Config.PublicPort)
 			publicServer := &http.Server{
 				Addr:              fmt.Sprintf(":%d", app.Config.PublicPort),
 				Handler:           PublicRouter(app),


### PR DESCRIPTION
First of all. Thank you so much for this project and the great work. For me, it really hits the sweet spot of how to integrate an authentication system :+1: 

Just saw this when starting the server with a public port defined. We already print the port in the Main.